### PR TITLE
Fix /metrics/find to handle glob * at the end

### DIFF
--- a/finder/base.go
+++ b/finder/base.go
@@ -56,7 +56,7 @@ func (b *BaseFinder) where(query string) string {
 		return w.String()
 	}
 
-	w.Andf("match(Path, %s)", Q(`^`+GlobToRegexp(query)+`$`))
+	w.Andf("match(Path, %s)", Q(`^`+GlobToRegexp(query)+`.?$`))
 	return w.String()
 }
 


### PR DESCRIPTION
wget -q -O -
'https://graphite/metrics/find/?format=completer&query=vmstats.foo-*.*'

before:
SELECT Path FROM graphite_tree WHERE (Level = 3) AND (Path LIKE
'vmstats.foo-%') AND (match(Path, '^vmstats.foo-([^.]*?).([^.]*?)$'))
GROUP BY Path HAVING argMax(Deleted, Version)==0

after:
SELECT Path FROM graphite_tree WHERE (Level = 3) AND (Path LIKE
'vmstats.foo-%') AND (match(Path, '^vmstats.foo-([^.]*?).([^.]*?).?$'))
GROUP BY Path HAVING argMax(Deleted, Version)==0

The dot must be optional as the full metric name does not end with a dot.