### PR TITLE
Work around bugs in Q().

### DIFF
--- a/finder/base.go
+++ b/finder/base.go
@@ -56,7 +56,9 @@ func (b *BaseFinder) where(query string) string {
 		return w.String()
 	}
 
-	w.Andf("match(Path, %s)", Q(`^`+GlobToRegexp(query)+`.?$`))
+	// Q() replaces \ with \\, so using \. does not work here.
+	// work around with [.]
+	w.Andf("match(Path, %s)", Q(`^`+GlobToRegexp(query)+`[.]?$`))
 	return w.String()
 }
 


### PR DESCRIPTION
Q() rewrites ```\.``` into ```\\.``` which is not what we want -
but it also does not escape a single ```.```
Work around using ```[.]```

Fix for #3 