### PR TITLE
Try to parse Clickhouse's config if we failed to parse our own

### DIFF
--- a/helper/rollup/rollup.go
+++ b/helper/rollup/rollup.go
@@ -59,6 +59,10 @@ type Rollup struct {
 	Default *Pattern   `xml:"default"`
 }
 
+type ClickhouseRollup struct {
+	Rollup Rollup `xml:"graphite_rollup"`
+}
+
 func (rr *Pattern) compile(hasRegexp bool) error {
 	var err error
 	if hasRegexp {
@@ -114,6 +118,16 @@ func ParseXML(body []byte) (*Rollup, error) {
 	err := xml.Unmarshal(body, r)
 	if err != nil {
 		return nil, err
+	}
+
+	// Maybe we've got Clickhouse's graphite.xml?
+	if r.Default == nil && r.Pattern == nil {
+		y := &ClickhouseRollup{}
+		err = xml.Unmarshal(body, y)
+		if err != nil {
+			return nil, err
+		}
+		r = &y.Rollup
 	}
 
 	err = r.compile()

--- a/helper/rollup/rollup_test.go
+++ b/helper/rollup/rollup_test.go
@@ -55,6 +55,57 @@ func TestParseXML(t *testing.T) {
 	}
 }
 
+
+func TestParseClickhouseXML(t *testing.T) {
+	config := `
+<yandex>
+	<graphite_rollup>
+		<pattern>
+			<regexp>click_cost</regexp>
+			<function>any</function>
+			<retention>
+				<age>0</age>
+				<precision>3600</precision>
+			</retention>
+			<retention>
+				<age>86400</age>
+				<precision>60</precision>
+			</retention>
+		</pattern>
+		<default>
+			<function>max</function>
+			<retention>
+				<age>0</age>
+				<precision>60</precision>
+			</retention>
+			<retention>
+				<age>3600</age>
+				<precision>300</precision>
+			</retention>
+			<retention>
+				<age>86400</age>
+				<precision>3600</precision>
+			</retention>
+		</default>
+	</graphite_rollup>
+</yandex>
+`
+
+	r, err := ParseXML([]byte(config))
+	t.Logf("%+v", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.Pattern[0].Retention[1].Age != 86400 {
+		t.FailNow()
+	}
+
+	if r.Default.Retention[2].Precision != 3600 {
+		t.FailNow()
+	}
+}
+
 func TestMetricPrecision(t *testing.T) {
 	tests := [][2][]point.Point{
 		{


### PR DESCRIPTION
If after parsing we got no default + rollup sections, try to parse
the file as it's clickhouse's graphite.xml.

This doesn't break compatibility with our own configuration format

Fixes #6