### PR TITLE
Fix/question mark

### DIFF
--- a/finder/where.go
+++ b/finder/where.go
@@ -10,15 +10,16 @@ import (
 func GlobToRegexp(g string) string {
 	s := g
 	s = strings.Replace(s, ".", "[.]", -1)
-	s = strings.Replace(s, "*", "([^.]*?)", -1)
 	s = strings.Replace(s, "{", "(", -1)
 	s = strings.Replace(s, "}", ")", -1)
+	s = strings.Replace(s, "?", "\\w{1}", -1)
 	s = strings.Replace(s, ",", "|", -1)
+	s = strings.Replace(s, "*", "([^.]*?)", -1)
 	return s
 }
 
 func HasWildcard(target string) bool {
-	return strings.IndexAny(target, "[]{}*") > -1
+	return strings.IndexAny(target, "[]{}*?") > -1
 }
 
 // Q quotes string for clickhouse

--- a/finder/where_test.go
+++ b/finder/where_test.go
@@ -14,6 +14,7 @@ func TestGlobToRegexp(t *testing.T) {
 	}{
 		{`test.*.foo`, `test[.]([^.]*?)[.]foo`},
 		{`test.{foo,bar}`, `test[.](foo|bar)`},
+		{`test?.foo`, `test\w{1}[.]foo`},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
clickhouse uses re2 regex library and there is no "?" symbol to match any symbol. 