### PR TITLE
More efficient SQL query for selecting points.

### DIFF
--- a/render/handler.go
+++ b/render/handler.go
@@ -187,7 +187,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	where := finder.NewWhere()
-	where.Andf("Path in (%s)", listBuf.String())
+	where.Andf("Path in (SELECT DISTINCT Path FROM %s WHERE Path IN (%s))", h.config.ClickHouse.TreeTable, listBuf.String())
 
 	until := untilTimestamp - untilTimestamp%int64(maxStep) + int64(maxStep) - 1
 	where.Andf("Time >= %d AND Time <= %d", fromTimestamp, until)


### PR DESCRIPTION
At RTB House we discovered with some luck that this form of the points query can be many times faster than the simple one, in particular when there are a lot of paths to look for. This might solve or at least greatly alleviate https://github.com/lomik/graphite-clickhouse/issues/22, with little effort.