### PR TITLE
Workaround of storage overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ total-timeout = "500ms"
 # # regexp.Match({target-match-all}, target[0]) && regexp.Match({target-match-all}, target[1]) && ...
 # target-match-all = "regexp"
 
+# Workaround for https://github.com/prometheus/prometheus/issues/4184
+# If used as prometheus remote read with downsampling set this values to prometheus
+# storage.tsdb.retention and storage.tsdb.max-block-duration parameters
+[prometheus]
+# skip-overlap = true
+# retention = "24h"
+# min-block-duration = "2h"
+
 [[logging]]
 logger = ""
 file = "/var/log/graphite-clickhouse/graphite-clickhouse.log"

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,12 @@ type Carbonlink struct {
 	TotalTimeout   *Duration `toml:"total-timeout"`
 }
 
+type Prometheus struct {
+	SkipOverlap      bool      `toml:"skip-overlap"`
+	Retention        *Duration `toml:"retention"`
+	MinBlockDuration *Duration `toml:"min-block-duration"`
+}
+
 type DataTable struct {
 	Table                string         `toml:"table"`
 	Reverse              bool           `toml:"reverse"`
@@ -103,6 +109,7 @@ type Config struct {
 	DataTable  []DataTable        `toml:"data-table"`
 	Tags       Tags               `toml:"tags"`
 	Carbonlink Carbonlink         `toml:"carbonlink"`
+	Prometheus Prometheus         `toml:"prometheus"`
 	Logging    []zapwriter.Config `toml:"logging"`
 	Rollup     *rollup.Rollup     `toml:"-"`
 }

--- a/prometheus/read.go
+++ b/prometheus/read.go
@@ -83,12 +83,12 @@ func (h *Handler) queryData(ctx context.Context, q *prompb.Query, metricList [][
 	if h.config.Prometheus.SkipOverlap {
 		now := time.Now()
 		// calculate min data in prometheus storage
-		localStorDate := now.Add(time.Duration(-1) * time.Duration(int64(h.config.Prometheus.Retention.Value().Seconds())) * time.Second)
-		localStorTimestamp := int64(localStorDate.Unix())
+		localStorDate := now.Add(-h.config.Prometheus.Retention.Value() - 2*h.config.Prometheus.MinBlockDuration.Value())
+		localStorTimestamp := localStorDate.Unix()
+		overlapTime := 2*int64(h.config.Prometheus.MinBlockDuration.Value().Seconds()) + 59
 
 		// check for overlap
-		if untilTimestamp < localStorTimestamp {
-			overlapTime := 2*int64(h.config.Prometheus.MinBlockDuration.Value().Seconds()) + 59
+		if untilTimestamp > localStorTimestamp {
 			untilTimestamp = untilTimestamp - overlapTime
 		}
 	}


### PR DESCRIPTION
Workaround for https://github.com/prometheus/prometheus/issues/4184

This commit add optional prometheus settings:
```
[prometheus]
skip-overlap = true
retention = "24h"
min-block-duration = "2h"
```
When skip-overlap is `True` skip overlap of `2 * min-block-duration + 59s`. 

1. Rate graph with sampling in clickhouse without this
![image](https://user-images.githubusercontent.com/16123585/51822578-dbb24e00-22ed-11e9-9db4-4f306c226bac.png)

2. Rate graph with sampling in clickhouse with this
![image](https://user-images.githubusercontent.com/16123585/51822594-e2d95c00-22ed-11e9-8000-886c782a70e1.png)
