### PR TITLE
add find results limit in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,9 +43,10 @@ type Common struct {
 	// MetricPrefix   string    `toml:"metric-prefix"`
 	// MetricInterval *Duration `toml:"metric-interval"`
 	// MetricEndpoint string    `toml:"metric-endpoint"`
-	MaxCPU          int              `toml:"max-cpu"`
-	TargetBlacklist []string         `toml:"target-blacklist"`
-	Blacklist       []*regexp.Regexp `toml:"-"` // compiled TargetBlacklist
+	MaxCPU                 int              `toml:"max-cpu"`
+	MaxMetricsInFindAnswer int              `toml:"max-metrics-in-find-answer"` //zero means infinite
+	TargetBlacklist        []string         `toml:"target-blacklist"`
+	Blacklist              []*regexp.Regexp `toml:"-"` // compiled TargetBlacklist
 }
 
 type ClickHouse struct {
@@ -118,7 +119,8 @@ func New() *Config {
 			// 	Duration: time.Minute,
 			// },
 			// MetricEndpoint: MetricEndpointLocal,
-			MaxCPU: 1,
+			MaxCPU:                 1,
+			MaxMetricsInFindAnswer: 0,
 		},
 		ClickHouse: ClickHouse{
 			Url: "http://localhost:8123",


### PR DESCRIPTION
Add config-param to limit number of results from /metrics/find/ handler