### PR TITLE
Remove Deleted = 0 predicate from queries

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -118,7 +118,6 @@ func (h *Handler) ServeTags(w http.ResponseWriter, r *http.Request) {
 
 	fromDate := time.Now().AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays)
 	where.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
-	where.Andf("Deleted = 0")
 
 	pw := ""
 	if prewhere != "" {
@@ -227,7 +226,6 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 
 	fromDate := time.Now().AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays)
 	where.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
-	where.Andf("Deleted = 0")
 
 	pw := ""
 	if prewhere != "" {

--- a/find/handler_test.go
+++ b/find/handler_test.go
@@ -60,11 +60,11 @@ func TestFind(t *testing.T) {
 
 	testCase(
 		"host.top.cpu.cpu%2A",
-		"SELECT Path FROM graphite_tree WHERE (Level = 4) AND (Path LIKE 'host.top.cpu.cpu%') AND (Deleted = 0) GROUP BY Path",
+		"SELECT Path FROM graphite_tree WHERE (Level = 4) AND (Path LIKE 'host.top.cpu.cpu%') GROUP BY Path",
 	)
 
 	testCase(
 		"host.?cpu",
-		"SELECT Path FROM graphite_tree WHERE (Level = 2) AND (Path LIKE 'host.%') AND (match(Path, '^host[.][^.]cpu[.]?$')) AND (Deleted = 0) GROUP BY Path",
+		"SELECT Path FROM graphite_tree WHERE (Level = 2) AND (Path LIKE 'host.%') AND (match(Path, '^host[.][^.]cpu[.]?$')) GROUP BY Path",
 	)
 }

--- a/finder/base.go
+++ b/finder/base.go
@@ -62,8 +62,6 @@ func (b *BaseFinder) where(query string) *Where {
 func (b *BaseFinder) Execute(ctx context.Context, query string, from int64, until int64) (err error) {
 	where := b.where(query)
 
-	where.And("Deleted = 0")
-
 	b.body, err = clickhouse.Query(
 		ctx,
 		b.url,

--- a/finder/date.go
+++ b/finder/date.go
@@ -38,7 +38,6 @@ func (b *DateFinder) Execute(ctx context.Context, query string, from int64, unti
 	)
 
 	if b.tableVersion == 2 {
-		where.And("Deleted = 0")
 		b.body, err = clickhouse.Query(
 			ctx,
 			b.url,

--- a/finder/date_reverse.go
+++ b/finder/date_reverse.go
@@ -25,7 +25,6 @@ func NewDateFinderV3(url string, table string, opts clickhouse.Options) Finder {
 
 func (f *DateFinderV3) Execute(ctx context.Context, query string, from int64, until int64) (err error) {
 	where := f.where(ReverseString(query))
-	where.And("Deleted = 0")
 
 	dateWhere := NewWhere()
 	dateWhere.Andf(

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -242,7 +242,7 @@ func (t *TaggedFinder) Execute(ctx context.Context, query string, from int64, un
 		prewhere = fmt.Sprintf("PREWHERE %s", pw)
 	}
 
-	sql := fmt.Sprintf("SELECT Path FROM %s %s WHERE (%s) AND (%s) AND (Deleted=0) GROUP BY Path", t.table, prewhere, dateWhere.String(), w)
+	sql := fmt.Sprintf("SELECT Path FROM %s %s WHERE (%s) AND (%s) GROUP BY Path", t.table, prewhere, dateWhere.String(), w)
 	t.body, err = clickhouse.Query(ctx, t.url, sql, t.table, t.opts)
 	return err
 }

--- a/index/index.go
+++ b/index/index.go
@@ -25,7 +25,7 @@ func New(config *config.Config, ctx context.Context) (*Index, error) {
 	reader, err := clickhouse.Reader(
 		ctx,
 		config.ClickHouse.Url,
-		fmt.Sprintf("SELECT Path FROM %s WHERE Deleted == 0 GROUP BY Path", config.ClickHouse.TreeTable),
+		fmt.Sprintf("SELECT Path FROM %s GROUP BY Path", config.ClickHouse.TreeTable),
 		config.ClickHouse.TreeTable,
 		opts,
 	)

--- a/prometheus/read.go
+++ b/prometheus/read.go
@@ -46,7 +46,6 @@ func (h *Handler) series(ctx context.Context, q *prompb.Query) ([][]byte, error)
 		time.Unix(q.EndTimestampMs/1000, 0).Format("2006-01-02"),
 	)
 	where.And(tagWhere)
-	where.And("Deleted = 0")
 
 	sql := fmt.Sprintf(
 		"SELECT Path FROM %s WHERE %s GROUP BY Path",

--- a/tagger/tagger.go
+++ b/tagger/tagger.go
@@ -122,7 +122,7 @@ func Make(cfg *config.Config) error {
 				context.WithValue(context.Background(), "logger", logger),
 				cfg.ClickHouse.Url,
 				fmt.Sprintf(
-					"SELECT Path FROM %s WHERE cityHash64(Path) %% %d == %d AND Deleted = 0 %s GROUP BY Path FORMAT RowBinary",
+					"SELECT Path FROM %s WHERE cityHash64(Path) %% %d = %d %s GROUP BY Path FORMAT RowBinary",
 					cfg.ClickHouse.TreeTable,
 					SelectChunksCount,
 					i,


### PR DESCRIPTION
As the Deleted column is not used anymore because ALTER TABLE DELETE Clickhouse query was introduced, we drop the comparison from queries.

The change should be backwards-compatible everywhere except old CH installations where we can potentially have Deleted != 0