### PR TITLE
Return 404 instead of 200/empty in protobuf

### DIFF
--- a/render/reply_protobuf.go
+++ b/render/reply_protobuf.go
@@ -15,6 +15,7 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 	points := data.Points.List()
 
 	if len(points) == 0 {
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
GraphiteWeb frontends like `carbonapi` expect a 404 response in case no data was found.
`carbonapi` generates code 500 because empty response from `graphite-clickhouse` does not contain `Content-Type` header (not that it should...)

So I think returning 404 in case we have no data is a good idea.