### PR TITLE
Add an option to specify from which table to get rollup info in auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ total-timeout = "500ms"
 # reverse = false
 # # custom rollup.conf for table. Or magic word `auto`
 # rollup-conf = ""
+# # Which table to discover rollup-rules from. If not specified - will use what specified in "table" parameter.
+# # Useful when reading from distributed table, but the rollup parameters are on the shard tables.
+# # Can be in "database.table" form.
+# rollup-auto-table = ""
 # # from >= now - {max-age}
 # max-age = "240h"
 # # until <= now - {min-age}

--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ type DataTable struct {
 	TargetMatchAnyRegexp *regexp.Regexp `toml:"-" json:"-"`
 	TargetMatchAllRegexp *regexp.Regexp `toml:"-" json:"-"`
 	RollupConf           string         `toml:"rollup-conf" json:"-"`
+	RollupAutoTable      string         `toml:"rollup-auto-table" json:"-"`
 	Rollup               *rollup.Rollup `toml:"-" json:"rollup-conf"`
 }
 
@@ -265,6 +266,7 @@ func ReadConfig(filename string) (*Config, error) {
 			}
 			cfg.DataTable[i].TargetMatchAnyRegexp = r
 		}
+
 		if cfg.DataTable[i].TargetMatchAll != "" {
 			r, err := regexp.Compile(cfg.DataTable[i].TargetMatchAll)
 			if err != nil {
@@ -274,10 +276,16 @@ func ReadConfig(filename string) (*Config, error) {
 		}
 
 		if cfg.DataTable[i].RollupConf == "auto" || cfg.DataTable[i].RollupConf == "" {
-			cfg.DataTable[i].Rollup, err = rollup.Auto(cfg.ClickHouse.Url, cfg.DataTable[i].Table, time.Minute)
+			table := cfg.DataTable[i].Table
+			if cfg.DataTable[i].RollupAutoTable != "" {
+				table = cfg.DataTable[i].RollupAutoTable
+			}
+
+			cfg.DataTable[i].Rollup, err = rollup.Auto(cfg.ClickHouse.Url, table, time.Minute)
 		} else {
 			cfg.DataTable[i].Rollup, err = rollup.ReadFromXMLFile(cfg.DataTable[i].RollupConf)
 		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When using distributed tables as a source of metrics we should get metrics not from it, but from underlying shard.

Add option `rollup-auto-table` to be able to specify it in `db.table` format. When this option is empty then the usual table name is used, which is backwards compatible.