### PR TITLE
Add rollup-default-precision option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ total-timeout = "500ms"
 # # Useful when reading from distributed table, but the rollup parameters are on the shard tables.
 # # Can be in "database.table" form.
 # rollup-auto-table = ""
+# # Sets the default precision for rollup patterns which don't have age=0 retention defined.
+# # If age=0 retention is defined in the rollup config then it takes precedence.
+# # If left at the default value of 0 then no rollup is performed when the requested interval 
+# # is not covered by any rollup rule. In this case the points will be served with 1 second precision.
+# rollup-default-precision = 0
 # # from >= now - {max-age}
 # max-age = "240h"
 # # until <= now - {min-age}

--- a/config/config.go
+++ b/config/config.go
@@ -96,19 +96,20 @@ type Prometheus struct {
 }
 
 type DataTable struct {
-	Table                string         `toml:"table" json:"table"`
-	Reverse              bool           `toml:"reverse" json:"reverse"`
-	MaxAge               *Duration      `toml:"max-age" json:"max-age"`
-	MinAge               *Duration      `toml:"min-age" json:"min-age"`
-	MaxInterval          *Duration      `toml:"max-interval" json:"max-interval"`
-	MinInterval          *Duration      `toml:"min-interval" json:"min-interval"`
-	TargetMatchAny       string         `toml:"target-match-any" json:"target-match-any"`
-	TargetMatchAll       string         `toml:"target-match-all" json:"target-match-all"`
-	TargetMatchAnyRegexp *regexp.Regexp `toml:"-" json:"-"`
-	TargetMatchAllRegexp *regexp.Regexp `toml:"-" json:"-"`
-	RollupConf           string         `toml:"rollup-conf" json:"-"`
-	RollupAutoTable      string         `toml:"rollup-auto-table" json:"-"`
-	Rollup               *rollup.Rollup `toml:"-" json:"rollup-conf"`
+	Table                  string         `toml:"table" json:"table"`
+	Reverse                bool           `toml:"reverse" json:"reverse"`
+	MaxAge                 *Duration      `toml:"max-age" json:"max-age"`
+	MinAge                 *Duration      `toml:"min-age" json:"min-age"`
+	MaxInterval            *Duration      `toml:"max-interval" json:"max-interval"`
+	MinInterval            *Duration      `toml:"min-interval" json:"min-interval"`
+	TargetMatchAny         string         `toml:"target-match-any" json:"target-match-any"`
+	TargetMatchAll         string         `toml:"target-match-all" json:"target-match-all"`
+	TargetMatchAnyRegexp   *regexp.Regexp `toml:"-" json:"-"`
+	TargetMatchAllRegexp   *regexp.Regexp `toml:"-" json:"-"`
+	RollupConf             string         `toml:"rollup-conf" json:"-"`
+	RollupAutoTable        string         `toml:"rollup-auto-table" json:"-"`
+	RollupDefaultPrecision uint32         `toml:"rollup-default-precision" json:"-"`
+	Rollup                 *rollup.Rollup `toml:"-" json:"rollup-conf"`
 }
 
 // Config ...
@@ -275,15 +276,16 @@ func ReadConfig(filename string) (*Config, error) {
 			cfg.DataTable[i].TargetMatchAllRegexp = r
 		}
 
+		rdp := cfg.DataTable[i].RollupDefaultPrecision
 		if cfg.DataTable[i].RollupConf == "auto" || cfg.DataTable[i].RollupConf == "" {
 			table := cfg.DataTable[i].Table
 			if cfg.DataTable[i].RollupAutoTable != "" {
 				table = cfg.DataTable[i].RollupAutoTable
 			}
 
-			cfg.DataTable[i].Rollup, err = rollup.Auto(cfg.ClickHouse.Url, table, time.Minute)
+			cfg.DataTable[i].Rollup, err = rollup.Auto(cfg.ClickHouse.Url, table, time.Minute, rdp)
 		} else {
-			cfg.DataTable[i].Rollup, err = rollup.ReadFromXMLFile(cfg.DataTable[i].RollupConf)
+			cfg.DataTable[i].Rollup, err = rollup.ReadFromXMLFile(cfg.DataTable[i].RollupConf, rdp)
 		}
 
 		if err != nil {

--- a/helper/rollup/rollup.go
+++ b/helper/rollup/rollup.go
@@ -12,14 +12,15 @@ import (
 )
 
 type Rollup struct {
-	mu       sync.RWMutex
-	rules    *Rules
-	addr     string
-	table    string
-	interval time.Duration
+	mu               sync.RWMutex
+	rules            *Rules
+	addr             string
+	table            string
+	defaultPrecision uint32
+	interval         time.Duration
 }
 
-func ReadFromXMLFile(filename string) (*Rollup, error) {
+func ReadFromXMLFile(filename string, defaultPrecision uint32) (*Rollup, error) {
 	rollupConfBody, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -30,14 +31,19 @@ func ReadFromXMLFile(filename string) (*Rollup, error) {
 		return nil, err
 	}
 
+	if defaultPrecision > 0 {
+		rules.addDefaultPrecision(defaultPrecision)
+	}
+
 	return &Rollup{rules: rules}, nil
 }
 
-func Auto(addr string, table string, interval time.Duration) (*Rollup, error) {
+func Auto(addr string, table string, interval time.Duration, defaultPrecision uint32) (*Rollup, error) {
 	r := &Rollup{
-		addr:     addr,
-		table:    table,
-		interval: interval,
+		addr:             addr,
+		table:            table,
+		interval:         interval,
+		defaultPrecision: defaultPrecision,
 	}
 
 	err := r.update()
@@ -63,6 +69,11 @@ func (r *Rollup) update() error {
 		zapwriter.Logger("rollup").Error(fmt.Sprintf("rollup rules update failed for table %#v", r.table), zap.Error(err))
 		return err
 	}
+
+	if r.defaultPrecision > 0 {
+		rules.addDefaultPrecision(r.defaultPrecision)
+	}
+
 	r.mu.Lock()
 	r.rules = rules
 	r.mu.Unlock()

--- a/helper/rollup/rules.go
+++ b/helper/rollup/rules.go
@@ -107,6 +107,21 @@ func (r *Rules) compile() error {
 	return nil
 }
 
+func (r *Rules) addDefaultPrecision(p uint32) {
+	for _, pt := range append(r.Pattern, r.Default) {
+		hasZeroAge := false
+		for _, rt := range pt.Retention {
+			if rt.Age == 0 {
+				hasZeroAge = true
+			}
+		}
+
+		if !hasZeroAge {
+			pt.Retention = append([]*Retention{&Retention{0, p}}, pt.Retention...)
+		}
+	}
+}
+
 func ParseXML(body []byte) (*Rules, error) {
 	r := &Rules{}
 	err := xml.Unmarshal(body, r)


### PR DESCRIPTION
This allows to choose the default precision when no retention rule is matched.