### PR TITLE
Clickhouse error handling

### DIFF
--- a/find/handler.go
+++ b/find/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 )
 
 type Handler struct {
@@ -21,7 +22,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	f, err := New(h.config, r.Context(), r.FormValue("query"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		clickhouse.HandleError(w, err)
 		return
 	}
 

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -20,9 +20,57 @@ import (
 	"go.uber.org/zap"
 )
 
+type ErrDataParse struct {
+	err  string
+	data string
+}
+
+func NewErrDataParse(err string, data string) error {
+	return &ErrDataParse{err, data}
+}
+
+func (e *ErrDataParse) Error() string {
+	return fmt.Sprintf("%s: %s", e.err, e.data)
+}
+
+func (e *ErrDataParse) PrependDescription(test string) {
+	e.data = test + e.data
+}
+
 var ErrUvarintRead = errors.New("ReadUvarint: Malformed array")
 var ErrUvarintOverflow = errors.New("ReadUvarint: varint overflows a 64-bit integer")
 var ErrClickHouseResponse = errors.New("Malformed response from clickhouse")
+
+func HandleError(w http.ResponseWriter, err error) {
+	netErr, ok := err.(net.Error)
+	if ok {
+		if netErr.Timeout() {
+			http.Error(w, "Storage read timeout", http.StatusGatewayTimeout)
+		} else if strings.HasSuffix(err.Error(), "connect: no route to host") ||
+			strings.HasSuffix(err.Error(), "connect: connection refused") ||
+			strings.HasSuffix(err.Error(), ": connection reset by peer") ||
+			strings.HasPrefix(err.Error(), "dial tcp: lookup ") { // DNS lookup
+			http.Error(w, "Storage error", http.StatusServiceUnavailable)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	_, ok = err.(*ErrDataParse)
+	if ok || strings.HasPrefix(err.Error(), "clickhouse response status 500: Code:") {
+		if strings.Contains(err.Error(), ": Limit for ") {
+			//logger.Info("limit", zap.Error(err))
+			http.Error(w, "Storage read limit", http.StatusForbidden)
+		} else if !ok && strings.HasPrefix(err.Error(), "clickhouse response status 500: Code: 170,") {
+			// distributed table configuration error
+			// clickhouse response status 500: Code: 170, e.displayText() = DB::Exception: Requested cluster 'cluster' not found
+			http.Error(w, "Storage configuration error", http.StatusServiceUnavailable)
+		}
+	} else {
+		//logger.Debug("query", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
 
 type Options struct {
 	Timeout        time.Duration

--- a/render/data.go
+++ b/render/data.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/helper/point"
 )
 
@@ -57,7 +58,8 @@ func ReadUvarint(array []byte) (uint64, int, error) {
 }
 
 type Data struct {
-	body    []byte // raw RowBinary from clickhouse
+	//body    []byte // raw RowBinary from clickhouse
+	length  int // readed bytes count
 	Points  *point.Points
 	nameMap map[string]string
 	Aliases map[string][]string
@@ -83,21 +85,21 @@ func DataSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err erro
 	namelen, readBytes, err := ReadUvarint(data)
 	if err == errUvarintRead {
 		if atEOF {
-			return 0, nil, errClickHouseResponse
+			return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
 		}
 		// signal for read more
 		return 0, nil, nil
 	}
 
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
 	}
 
 	tokenLen := int(readBytes) + int(namelen) + 16
 
 	if len(data) < tokenLen {
 		if atEOF {
-			return 0, nil, errClickHouseResponse
+			return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
 		}
 		// signal for read more
 		return 0, nil, nil
@@ -134,14 +136,19 @@ func DataParse(bodyReader io.Reader, extraPoints *point.Points, isReverse bool) 
 	scanner.Buffer(make([]byte, 1048576), 1048576)
 	scanner.Split(DataSplitFunc)
 
-	for scanner.Scan() {
-		row := scanner.Bytes()
+	var row_start []byte
 
-		namelen, readBytes, err := ReadUvarint(row)
+	for scanner.Scan() {
+		row_start = scanner.Bytes()
+
+		d.length += len(row_start)
+
+		namelen, readBytes, err := ReadUvarint(row_start)
 		if err != nil {
 			return nil, errClickHouseResponse
 		}
-		row = row[int(readBytes):]
+
+		row := row_start[int(readBytes):]
 
 		newName := row[:int(namelen)]
 		row = row[int(namelen):]
@@ -172,9 +179,13 @@ func DataParse(bodyReader io.Reader, extraPoints *point.Points, isReverse bool) 
 		pp.AppendPoint(metricID, value, time, timestamp)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, err
+	err := scanner.Err()
+	if err != nil {
+		dataErr, ok := err.(*clickhouse.ErrDataParse)
+		if ok {
+			// format full error string
+			dataErr.PrependDescription(string(row_start))
+		}
 	}
-
-	return d, nil
+	return d, err
 }

--- a/render/handler.go
+++ b/render/handler.go
@@ -140,6 +140,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if h.config.Common.MaxMetricsInFindAnswer > 0 && h.config.Common.MaxMetricsInFindAnswer < len(aliases) {
+		logger.Info("limit", zap.Int("metric_find", len(aliases)))
+		http.Error(w, fmt.Sprintf("Too much metric: %d", len(aliases)), http.StatusForbidden)
+		return
+	}
+
 	metricList := make([][]byte, len(aliases))
 	index := 0
 	for metric, _ := range aliases {


### PR DESCRIPTION
Clickhouse errors handling. Also improved limits checking.
For example return:
403 (Forbidden) status code on limit reached
503 (Service Unavailable) for local storage fatal error
504 (Gateway Timeout) read timeout from storage
For other error return 500 status code (as earlier).

May be useful for check on load balancers and limiting queries.