### PR TITLE
Clickhouse errors handling

### DIFF
--- a/find/handler.go
+++ b/find/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 )
 
 type Handler struct {
@@ -21,7 +22,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	f, err := New(h.config, r.Context(), r.FormValue("query"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		clickhouse.HandleError(w, err)
 		return
 	}
 

--- a/find/handler.go
+++ b/find/handler.go
@@ -20,7 +20,12 @@ func NewHandler(config *config.Config) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.ParseMultipartForm(1024 * 1024)
 
-	f, err := New(h.config, r.Context(), r.FormValue("query"))
+	query := r.FormValue("query")
+	if len(query) == 0 {
+		http.Error(w, "Query not set", http.StatusBadRequest)
+		return
+	}
+	f, err := New(h.config, r.Context(), query)
 	if err != nil {
 		clickhouse.HandleError(w, err)
 		return

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -20,9 +20,57 @@ import (
 	"go.uber.org/zap"
 )
 
+type ErrDataParse struct {
+	err  string
+	data string
+}
+
+func NewErrDataParse(err string, data string) error {
+	return &ErrDataParse{err, data}
+}
+
+func (e *ErrDataParse) Error() string {
+	return fmt.Sprintf("%s: %s", e.err, e.data)
+}
+
+func (e *ErrDataParse) PrependDescription(test string) {
+	e.data = test + e.data
+}
+
 var ErrUvarintRead = errors.New("ReadUvarint: Malformed array")
 var ErrUvarintOverflow = errors.New("ReadUvarint: varint overflows a 64-bit integer")
 var ErrClickHouseResponse = errors.New("Malformed response from clickhouse")
+
+func HandleError(w http.ResponseWriter, err error) {
+	netErr, ok := err.(net.Error)
+	if ok {
+		if netErr.Timeout() {
+			http.Error(w, "Storage read timeout", http.StatusGatewayTimeout)
+		} else if strings.HasSuffix(err.Error(), "connect: no route to host") ||
+			strings.HasSuffix(err.Error(), "connect: connection refused") ||
+			strings.HasSuffix(err.Error(), ": connection reset by peer") ||
+			strings.HasPrefix(err.Error(), "dial tcp: lookup ") { // DNS lookup
+			http.Error(w, "Storage error", http.StatusServiceUnavailable)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	_, ok = err.(*ErrDataParse)
+	if ok || strings.HasPrefix(err.Error(), "clickhouse response status 500: Code:") {
+		if strings.Contains(err.Error(), ": Limit for ") {
+			//logger.Info("limit", zap.Error(err))
+			http.Error(w, "Storage read limit", http.StatusForbidden)
+		} else if !ok && strings.HasPrefix(err.Error(), "clickhouse response status 500: Code: 170,") {
+			// distributed table configuration error
+			// clickhouse response status 500: Code: 170, e.displayText() = DB::Exception: Requested cluster 'cluster' not found
+			http.Error(w, "Storage configuration error", http.StatusServiceUnavailable)
+		}
+	} else {
+		//logger.Debug("query", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
 
 type Options struct {
 	Timeout        time.Duration

--- a/render/handler.go
+++ b/render/handler.go
@@ -124,7 +124,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Search in small index table first
 		fndResult, err := finder.Find(h.config, r.Context(), target, fromTimestamp, untilTimestamp)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			clickhouse.HandleError(w, err)
 			return
 		}
 
@@ -147,6 +147,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metricList[index] = []byte(metric)
 		index++
 	}
+
+	logger.Info("finder", zap.Int("metrics", len(aliases)))
 
 	pointsTable, isReverse, rollupObj := SelectDataTable(h.config, fromTimestamp, untilTimestamp, targets)
 	if pointsTable == "" {
@@ -236,7 +238,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		clickhouse.HandleError(w, err)
 		return
 	}
 
@@ -249,9 +251,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	data, err := DataParse(body, carbonlinkData, isReverse)
 
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Error("data", zap.Error(err), zap.Int("read_bytes", data.length))
+		clickhouse.HandleError(w, err)
 		return
 	}
+	logger.Info("render", zap.Int("read_bytes", data.length), zap.Int("read_points", data.Points.Len()))
 
 	d := time.Since(parseStart)
 	logger.Debug("parse", zap.String("runtime", d.String()), zap.Duration("runtime_ns", d))


### PR DESCRIPTION
Clickhouse errors handling. Also improved limits checking.
For example return:
403 (Forbidden) status code on limit reached
503 (Service Unavailable) for local storage fatal error
504 (Gateway Timeout) read timeout from storage
For other error return 500 status code (as earlier).

May be useful for check on load balancers. We can retry some queries (for example with 503 or 504 status code, or 500 status code with carefully) on next upstream and don't do that on limit reached.