### PR TITLE
Add memory-return-interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Create `/etc/graphite-clickhouse/graphite-clickhouse.conf`
 [common]
 listen = ":9090"
 max-cpu = 1
+# How frequently to call debug.FreeOSMemory() to return memory back to OS
+# Setting it to zero disables this functionality
+memory-return-interval = "0s"
 # Limit number of results from find query. Zero = unlimited
 max-metrics-in-find-answer = 0
 # Daemon returns empty response if query matches any of regular expressions

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Common struct {
 	MaxMetricsInFindAnswer int              `toml:"max-metrics-in-find-answer" json:"max-metrics-in-find-answer"` //zero means infinite
 	TargetBlacklist        []string         `toml:"target-blacklist" json:"target-blacklist"`
 	Blacklist              []*regexp.Regexp `toml:"-" json:"-"` // compiled TargetBlacklist
+	MemoryReturnInterval   *Duration        `toml:"memory-return-interval" json:"memory-return-interval"`
 }
 
 type ClickHouse struct {

--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/lomik/graphite-clickhouse/autocomplete"
@@ -126,6 +127,17 @@ func main() {
 	}
 
 	runtime.GOMAXPROCS(cfg.Common.MaxCPU)
+
+	if cfg.Common.MemoryReturnInterval.Duration > 0 {
+		go func() {
+			t := time.NewTicker(cfg.Common.MemoryReturnInterval.Duration)
+
+			for {
+				<-t.C
+				debug.FreeOSMemory()
+			}
+		}()
+	}
 
 	/* CONFIG end */
 


### PR DESCRIPTION
When requesting a lot of metrics from Clickhouse we allocate lots of memory and Go's GC is very slow at returning it back to the OS which in some cases might lead to OOM.

This parameter forces Go to periodically return memory to OS.
This, of course, has downsides like more memory fragmentation, more allocations etc, but sometimes it's invaluable.

Maybe we should think about more sophisticated approach, like returning memory after the request if no more requests are coming for some duration.