### PR TITLE
Decrease amount of transfered data with aggregation by Path

### DIFF
--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -82,7 +82,7 @@ func (q *Querier) Select(selectParams *storage.SelectParams, labelsMatcher ...*l
 	pw := where.New()
 	pw.And(where.DateBetween("Date", from, until))
 
-	query := fmt.Sprintf(`SELECT Path, Time, Value, Timestamp FROM %s %s %s FORMAT RowBinary`,
+	query := fmt.Sprintf(render.QUERY,
 		pointsTable, pw.PreWhereSQL(), wr.SQL(),
 	)
 

--- a/prometheus/read.go
+++ b/prometheus/read.go
@@ -81,7 +81,7 @@ func (h *Handler) queryData(ctx context.Context, q *prompb.Query, am *alias.Map)
 	until := untilTimestamp - untilTimestamp%int64(maxStep) + int64(maxStep) - 1
 	wr.Andf("Time >= %d AND Time <= %d", fromTimestamp, until)
 
-	query := fmt.Sprintf(`SELECT Path, Time, Value, Timestamp FROM %s %s %s	FORMAT RowBinary`,
+	query := fmt.Sprintf(render.QUERY,
 		pointsTable, pw.PreWhereSQL(), wr.SQL(),
 	)
 

--- a/render/data.go
+++ b/render/data.go
@@ -18,6 +18,9 @@ var errUvarintRead = errors.New("ReadUvarint: Malformed array")
 var errUvarintOverflow = errors.New("ReadUvarint: varint overflows a 64-bit integer")
 var errClickHouseResponse = errors.New("Malformed response from clickhouse")
 
+// QUERY to get data from ClickHouse
+const QUERY = `SELECT Path, groupArray(Time), groupArray(Value), groupArray(Timestamp) FROM %s %s %s GROUP BY Path FORMAT RowBinary`
+
 func ReadUvarint(array []byte) (uint64, int, error) {
 	var x uint64
 	var s uint
@@ -56,33 +59,54 @@ func (d *Data) finalName(name string) string {
 	return s
 }
 
+// Error handler for DataSplitFunc
+func splitErrorHandler(data *[]byte, atEOF bool, err error) (int, []byte, error) {
+	if err == errUvarintRead {
+		if atEOF {
+			return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(*data))
+		}
+		// signal for read more
+		return 0, nil, nil
+	} else if err != nil {
+		return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(*data))
+	}
+	// signal for read more
+	return 0, nil, nil
+}
+
 // DataSplitFunc is split function for bufio.Scanner for read row binary records with data
 func DataSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if len(data) == 0 && atEOF {
 		// stop
 		return 0, nil, nil
 	}
-	namelen, readBytes, err := ReadUvarint(data)
-	if err == errUvarintRead {
-		if atEOF {
-			return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
-		}
-		// signal for read more
-		return 0, nil, nil
+
+	nameLen, readBytes, err := ReadUvarint(data)
+	tokenLen := int(readBytes) + int(nameLen)
+	if err != nil || len(data) < tokenLen {
+		return splitErrorHandler(&data, atEOF, err)
 	}
 
-	if err != nil {
+	timeLen, readBytes, err := ReadUvarint(data[tokenLen:])
+	tokenLen += int(readBytes) + int(timeLen)*4
+	if err != nil || len(data) < tokenLen {
+		return splitErrorHandler(&data, atEOF, err)
+	}
+
+	valueLen, readBytes, err := ReadUvarint(data[tokenLen:])
+	tokenLen += int(readBytes) + int(valueLen)*8
+	if err != nil || len(data) < tokenLen {
+		return splitErrorHandler(&data, atEOF, err)
+	}
+
+	timestampLen, readBytes, err := ReadUvarint(data[tokenLen:])
+	tokenLen += int(readBytes) + int(timestampLen)*4
+	if err != nil || len(data) < tokenLen {
+		return splitErrorHandler(&data, atEOF, err)
+	}
+
+	if !(timeLen == valueLen && timeLen == timestampLen) {
 		return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
-	}
-
-	tokenLen := int(readBytes) + int(namelen) + 16
-
-	if len(data) < tokenLen {
-		if atEOF {
-			return 0, nil, clickhouse.NewErrDataParse(errClickHouseResponse.Error(), string(data))
-		}
-		// signal for read more
-		return 0, nil, nil
 	}
 
 	return tokenLen, data[:tokenLen], nil
@@ -123,15 +147,15 @@ func DataParse(bodyReader io.Reader, extraPoints *point.Points, isReverse bool) 
 
 		d.length += len(rowStart)
 
-		namelen, readBytes, err := ReadUvarint(rowStart)
+		nameLen, readBytes, err := ReadUvarint(rowStart)
 		if err != nil {
 			return nil, errClickHouseResponse
 		}
 
 		row := rowStart[int(readBytes):]
 
-		newName := row[:int(namelen)]
-		row = row[int(namelen):]
+		newName := row[:int(nameLen)]
+		row = row[int(nameLen):]
 
 		if bytes.Compare(newName, name) != 0 {
 			if len(newName) > len(nameBuf) {
@@ -148,15 +172,36 @@ func DataParse(bodyReader io.Reader, extraPoints *point.Points, isReverse bool) 
 			}
 		}
 
-		time := binary.LittleEndian.Uint32(row[:4])
-		row = row[4:]
+		arrayLen, readBytes, err := ReadUvarint(row)
+		if err != nil {
+			return nil, errClickHouseResponse
+		}
 
-		value := math.Float64frombits(binary.LittleEndian.Uint64(row[:8]))
-		row = row[8:]
+		times := make([]uint32, arrayLen)
+		values := make([]float64, arrayLen)
+		timestamps := make([]uint32, arrayLen)
 
-		timestamp := binary.LittleEndian.Uint32(row[:4])
+		row = row[int(readBytes):]
+		for i := uint64(0); i < arrayLen; i++ {
+			times[i] = binary.LittleEndian.Uint32(row[:4])
+			row = row[4:]
+		}
 
-		pp.AppendPoint(metricID, value, time, timestamp)
+		row = row[int(readBytes):]
+		for i := uint64(0); i < arrayLen; i++ {
+			values[i] = math.Float64frombits(binary.LittleEndian.Uint64(row[:8]))
+			row = row[8:]
+		}
+
+		row = row[int(readBytes):]
+		for i := uint64(0); i < arrayLen; i++ {
+			timestamps[i] = binary.LittleEndian.Uint32(row[:4])
+			row = row[4:]
+		}
+
+		for i := range times {
+			pp.AppendPoint(metricID, values[i], times[i], timestamps[i])
+		}
 	}
 
 	err := scanner.Err()

--- a/render/handler.go
+++ b/render/handler.go
@@ -159,7 +159,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	until := untilTimestamp - untilTimestamp%int64(maxStep) + int64(maxStep) - 1
 	wr.And(where.TimestampBetween("Time", fromTimestamp, until))
 
-	query := fmt.Sprintf(`SELECT Path, Time, Value, Timestamp FROM %s %s %s FORMAT RowBinary`,
+	query := fmt.Sprintf(QUERY,
 		pointsTable, pw.PreWhereSQL(), wr.SQL(),
 	)
 


### PR DESCRIPTION
Here is a code for #60 

With our 10Gbit network, there is no significant acceleration. But the amount of transferred data is decreased 6 times:

```
# upstream
[2019-09-02T06:39:34.284Z] INFO finder {"request_id": "6221247fed568342ef8eb6dc365588d5", "metrics": 25836}
[2019-09-02T06:39:49.508Z] INFO [query] query {"query": "SELECT Path, Time, Value, Timestamp FROM graphite.carbon PREWHERE Date >='2019-08-30' AND Date <= '2019-08-30' WHERE (Path IN (<...>)) AND (Time >= 1567134864 AND Time <= 1567178099) FORMAT RowBinary", "request_id": "6221247fed568342ef8eb6dc365588d5", "time": 14.247405276}
[2019-09-02T06:39:49.508Z] INFO render {"request_id": "6221247fed568342ef8eb6dc365588d5", "read_bytes": 1893367324, "read_points": 18549891}
[2019-09-02T06:39:49.508Z] DEBUG parse {"request_id": "6221247fed568342ef8eb6dc365588d5", "runtime": "9.496039402s", "runtime_ns": 9.496039402}
[2019-09-02T06:39:53.068Z] DEBUG sort {"request_id": "6221247fed568342ef8eb6dc365588d5", "runtime": "3.560176051s", "runtime_ns": 3.560176051}
[2019-09-02T06:39:59.478Z] DEBUG rollup {"request_id": "6221247fed568342ef8eb6dc365588d5", "runtime": "1.401853138s", "runtime_ns": 1.401853138}
[2019-09-02T06:39:59.478Z] DEBUG pickle {"request_id": "6221247fed568342ef8eb6dc365588d5", "runtime": "4.645392012s", "runtime_ns": 4.645392012}
[2019-09-02T06:39:59.478Z] DEBUG reply {"request_id": "6221247fed568342ef8eb6dc365588d5", "runtime": "6.306056204s", "runtime_ns": 6.306056204}
[2019-09-02T06:39:59.478Z] INFO access {"request_id": "6221247fed568342ef8eb6dc365588d5", "time": 25.38388494, "method": "GET", "url": "/render/?format=pickle&local=1&noCache=1&from=1567134864&until=1567178064&target=<...>&now=1567178064", "peer": "127.0.0.1:60430", "status": 200}


# with patch
[2019-09-02T06:39:05.454Z] INFO finder {"request_id": "2d90045ec404d7f057753948489015d3", "metrics": 25836}
[2019-09-02T06:39:20.845Z] INFO [query] query {"query": "SELECT Path, groupArray(Time), groupArray(Value), groupArray(Timestamp) FROM graphite.carbon PREWHERE Date >='2019-08-30' AND Date <= '2019-08-30' WHERE (Path IN (<...>)) AND (Time >= 1567134864 AND Time <= 1567178099) GROUP BY Path FORMAT RowBinary", "request_id": "2d90045ec404d7f057753948489015d3", "time": 14.383664671}
[2019-09-02T06:39:20.845Z] INFO render {"request_id": "2d90045ec404d7f057753948489015d3", "read_bytes": 299176954, "read_points": 18549891}
[2019-09-02T06:39:20.845Z] DEBUG parse {"request_id": "2d90045ec404d7f057753948489015d3", "runtime": "5.312247309s", "runtime_ns": 5.312247309}
[2019-09-02T06:39:23.788Z] DEBUG sort {"request_id": "2d90045ec404d7f057753948489015d3", "runtime": "2.942685954s", "runtime_ns": 2.942685954}
[2019-09-02T06:39:30.036Z] DEBUG rollup {"request_id": "2d90045ec404d7f057753948489015d3", "runtime": "1.304685963s", "runtime_ns": 1.304685963}
[2019-09-02T06:39:30.036Z] DEBUG pickle {"request_id": "2d90045ec404d7f057753948489015d3", "runtime": "4.461564452s", "runtime_ns": 4.461564452}
[2019-09-02T06:39:30.036Z] DEBUG reply {"request_id": "2d90045ec404d7f057753948489015d3", "runtime": "5.991442156s", "runtime_ns": 5.991442156}
[2019-09-02T06:39:30.036Z] INFO access {"request_id": "2d90045ec404d7f057753948489015d3", "time": 24.759430571, "method": "GET", "url": "/render/?format=pickle&local=1&noCache=1&from=1567134864&until=1567178064&target=<...>&now=1567178064", "peer": "127.0.0.1:42114", "status": 200}
```