### PR TITLE
Make Prometheus an optional dependency

### DIFF
--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/handlerDummy.go
+++ b/prometheus/handlerDummy.go
@@ -1,0 +1,18 @@
+// +build noprom
+
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/lomik/graphite-clickhouse/config"
+)
+
+type HandlerDummy struct{}
+
+func (h *HandlerDummy) ServeHTTP(http.ResponseWriter, *http.Request) {
+}
+
+func NewHandler(config *config.Config) *HandlerDummy {
+	return &HandlerDummy{}
+}

--- a/prometheus/labels.go
+++ b/prometheus/labels.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/matcher.go
+++ b/prometheus/matcher.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/metrics_set.go
+++ b/prometheus/metrics_set.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/read.go
+++ b/prometheus/read.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (

--- a/prometheus/series_set.go
+++ b/prometheus/series_set.go
@@ -1,3 +1,5 @@
+// +build !noprom
+
 package prometheus
 
 import (


### PR DESCRIPTION
With Prometheus we get shitload of dependencies and binary size increases by 380% from 14MB to 54MB. As some people like us don't need this feature it would be nice to be able to exclude it.

This PR adds a `noprom` build tag which will skip all Prometheus-dependent code and will install a dummy handler on `/` instead of real Prometheus one. Maybe there's more elegant way to do it but for now I guess it will do the job.

The default behavior is not changing so it should be backwards compatible.