### PR TITLE
Allow to use graphite..inner.data as rollup table

### DIFF
--- a/helper/rollup/remote.go
+++ b/helper/rollup/remote.go
@@ -103,10 +103,7 @@ func parseJson(body []byte) (*Rules, error) {
 
 func remoteLoad(addr string, table string) (*Rules, error) {
 	var db string
-	arr := strings.Split(table, ".")
-	if len(arr) > 2 {
-		return nil, fmt.Errorf("wrong table name %#v", table)
-	}
+	arr := strings.SplitN(table, ".", 2)
 	if len(arr) == 1 {
 		db = "default"
 	} else {


### PR DESCRIPTION
Currently, it returns an error:

```
[2020-05-12T11:27:06.082Z] ERROR [rollup] rollup rules update failed for table "graphite..inner.data" {"error": "wrong table name \"graphite..inner.data\""}
```

But when MaterializedView is used, the inner table should be used.

This PR allows us to use it with, as far as I see, the perfect backward compatibility.