### PR TITLE
Fix broken deb-compression fpm argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ fpm-build-deb:
 	fpm -s dir -t deb -n $(NAME) -v $(VERSION) \
 		--deb-priority optional --category admin \
 		--force \
-		--deb-compression bzip2 \
 		--url https://github.com/lomik/$(NAME) \
 		--description $(DESCRIPTION) \
 		-m $(MAINTAINER) \


### PR DESCRIPTION
FPM argument `deb-compression` is broken for a while and hasn't been merged despite it has a fix in https://github.com/jordansissel/fpm/pull/1611 and https://github.com/jordansissel/fpm/pull/1623

Now it produces a wrong control file and causes вздржнь in dpkg:

```
┌[17:18:48] felixoid@fel:~/OPT/Felixoid/github/lomik/graphite-clickhouse [master↑1|…7]
└>±> ar t graphite-clickhouse_0.11.7-22-g0614915_amd64.deb
debian-binary
control.tar.gz
data.tar.bz2
┌[17:18:54] felixoid@fel:~/OPT/Felixoid/github/lomik/graphite-clickhouse [master↑1|…7]
└>±> ar x graphite-clickhouse_0.11.7-22-g0614915_amd64.deb
┌[17:19:03] felixoid@fel:~/OPT/Felixoid/github/lomik/graphite-clickhouse [master↑1|…7]
└>±> file control.tar.gz
control.tar.gz: bzip2 compressed data, block size = 900k
```