### PR TITLE
Use the same start/stop/step logic as in graphite-web

### DIFF
--- a/render/reply_pickle.go
+++ b/render/reply_pickle.go
@@ -62,13 +62,13 @@ func (h *Handler) ReplyPickle(w http.ResponseWriter, r *http.Request, data *Data
 		if start < from {
 			start += step
 		}
-		end := until - (until % step)
+		end := until - (until % step) + step
 		last := start - step
 
 		p.String("values")
 		p.List()
 		for _, point := range points {
-			if point.Time < start || point.Time > end {
+			if point.Time < start || point.Time >= end {
 				continue
 			}
 
@@ -81,8 +81,8 @@ func (h *Handler) ReplyPickle(w http.ResponseWriter, r *http.Request, data *Data
 			last = point.Time
 		}
 
-		if end > last {
-			p.AppendNulls(int((end - last) / step))
+		if end-step > last {
+			p.AppendNulls(int(((end - last) / step) - 1))
 		}
 		p.SetItem()
 

--- a/render/reply_protobuf.go
+++ b/render/reply_protobuf.go
@@ -32,8 +32,8 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 		if start < from {
 			start += step
 		}
-		stop := until - (until % step)
-		count := ((stop - start) / step) + 1
+		stop := until - (until % step) + step
+		count := ((stop - start) / step)
 
 		mb.Reset()
 
@@ -75,7 +75,7 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 
 		last := start - step
 		for _, point := range points {
-			if point.Time < start || point.Time > stop {
+			if point.Time < start || point.Time >= stop {
 				continue
 			}
 
@@ -88,8 +88,8 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 			last = point.Time
 		}
 
-		if stop > last {
-			ProtobufWriteDoubleN(writer, 0, int((stop-last)/step))
+		if stop-step > last {
+			ProtobufWriteDoubleN(writer, 0, int(((stop-last)/step)-1))
 		}
 
 		// Write isAbsent
@@ -98,7 +98,7 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 
 		last = start - step
 		for _, point := range points {
-			if point.Time < start || point.Time > stop {
+			if point.Time < start || point.Time >= stop {
 				continue
 			}
 
@@ -111,8 +111,8 @@ func (h *Handler) ReplyProtobuf(w http.ResponseWriter, r *http.Request, data *Da
 			last = point.Time
 		}
 
-		if stop > last {
-			WriteByteN(writer, '\x01', int((stop-last)/step))
+		if stop-step > last {
+			WriteByteN(writer, '\x01', int(((stop-last)/step)-1))
 		}
 	}
 


### PR DESCRIPTION
We've faced an issue, that graphite-clickhouse calculates the start/stop/step parameters of the metrics slightly different than graphite-web. From the functions tests, there are examples with a proper set of TimeSeries parameters:  
https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L434-L435  
https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L556  
https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L591  
https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L663  
https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L1975  
etc.

It looks like graphite-web is somehow tolerant to the start/stop/step, but after go-graphite/carbonapi#501 was merged, it still has problems, because the main logic fits the graphite-web, but graphite-clickhouse sends the data with another start/step/stop formula.