### PR TITLE
Fix steps calculation when using reverse-points

### DIFF
--- a/render/query.go
+++ b/render/query.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/helper/rollup"
 	"github.com/lomik/graphite-clickhouse/pkg/alias"
 	"github.com/lomik/graphite-clickhouse/pkg/dry"
+	"github.com/lomik/graphite-clickhouse/pkg/reverse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
 	"go.uber.org/zap"
@@ -315,6 +316,10 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 		steps[m] = step
 		if int64(step) > maxStep {
 			maxStep = int64(step)
+		}
+
+		if targets.isReverse {
+			m = reverse.String(m)
 		}
 	}
 	until := dry.CeilToMultiplier(tf.Until, maxStep) - 1

--- a/render/query.go
+++ b/render/query.go
@@ -313,7 +313,6 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 	steps := make(map[string]uint32)
 	for _, m := range metricList {
 		step, _ := targets.rollupObj.Lookup(m, uint32(age))
-		steps[m] = step
 		if int64(step) > maxStep {
 			maxStep = int64(step)
 		}
@@ -321,6 +320,8 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 		if targets.isReverse {
 			m = reverse.String(m)
 		}
+
+		steps[m] = step
 	}
 	until := dry.CeilToMultiplier(tf.Until, maxStep) - 1
 


### PR DESCRIPTION
Current master panics for me on any request when using reverse-points as the metricList map is filled with forward metrics and idMap in points contains reversed metrics.

So all map lookups in SetSteps() fail and step 0 always returned by GetSteps() which leads to a division by zero:
```
runtime error: integer divide by zero
Stack trace: github.com/lomik/graphite-clickhouse/render.(*Handler).ServeHTTP.func1
	/Users/igor/git/graphite-clickhouse/render/handler.go:47
runtime.gopanic
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:969
runtime.panicdivide
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:191
github.com/lomik/graphite-clickhouse/render.writePB2
	/Users/igor/git/graphite-clickhouse/render/pb2_writer.go:11
github.com/lomik/graphite-clickhouse/render.(*Handler).ReplyProtobuf.func1
	/Users/igor/git/graphite-clickhouse/render/reply_protobuf.go:54
github.com/lomik/graphite-clickhouse/render.(*Handler).ReplyProtobuf
	/Users/igor/git/graphite-clickhouse/render/reply_protobuf.go:67
github.com/lomik/graphite-clickhouse/render.(*Handler).Reply
	/Users/igor/git/graphite-clickhouse/render/handler.go:182
github.com/lomik/graphite-clickhouse/render.(*Handler).ServeHTTP
	/Users/igor/git/graphite-clickhouse/render/handler.go:171
main.Handler.func1
	/Users/igor/git/graphite-clickhouse/graphite-clickhouse.go:67
net/http.HandlerFunc.ServeHTTP
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2042
net/http.(*ServeMux).ServeHTTP
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2417
net/http.serverHandler.ServeHTTP
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2843
net/http.(*conn).serve
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:1925
```

This PR is a quick hack around, maybe there's a better way.