### PR TITLE
Fix hanging goroutines

### DIFF
--- a/render/handler.go
+++ b/render/handler.go
@@ -160,6 +160,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reply, err := FetchDataPoints(r.Context(), h.config, fetchRequests, config.ContextGraphite)
 	if err != nil {
 		clickhouse.HandleError(w, err)
+		return
 	}
 
 	if len(reply.CHResponses) == 0 {

--- a/render/query.go
+++ b/render/query.go
@@ -81,6 +81,8 @@ func FetchDataPoints(ctx context.Context, cfg *config.Config, fetchRequests Mult
 	var lock sync.RWMutex
 	var wg sync.WaitGroup
 	logger := scope.Logger(ctx)
+	ctxTimeout, cancel := context.WithTimeout(ctx, cfg.ClickHouse.DataTimeout.Duration)
+	defer cancel()
 	cStep := &commonStep{
 		result: 0,
 		wg:     sync.WaitGroup{},
@@ -114,7 +116,7 @@ func FetchDataPoints(ctx context.Context, cfg *config.Config, fetchRequests Mult
 		wg.Add(1)
 		go func(tf TimeFrame, targets *Targets) {
 			defer wg.Done()
-			err := reply.getDataPoints(ctx, cfg, tf, targets)
+			err := reply.getDataPoints(ctxTimeout, cfg, tf, targets)
 			if err != nil {
 				lock.Lock()
 				errors = append(errors, err)
@@ -278,7 +280,7 @@ func (r *Reply) getDataAggregated(ctx context.Context, cfg *config.Config, tf Ti
 	}
 
 	carbonlinkData := carbonlinkResponseRead()
-	data, err = parseAggregatedResponse(b, e, carbonlinkData, targets.isReverse)
+	data, err = parseAggregatedResponse(ctx, b, e, carbonlinkData, targets.isReverse)
 	if err != nil {
 		logger.Error("data", zap.Error(err), zap.Int("read_bytes", data.length))
 		return nil, err

--- a/render/query.go
+++ b/render/query.go
@@ -155,7 +155,7 @@ func (r *Reply) getDataPoints(ctx context.Context, cfg *config.Config, tf TimeFr
 	}
 
 	if err != nil {
-		return nil
+		return err
 	}
 
 	logger.Info("data", zap.Int("read_bytes", data.length), zap.Int("read_points", data.Points.Len()))


### PR DESCRIPTION
I've faced a lot of hanged `github.com/lomik/graphite-clickhouse/render.parseAggregatedResponse` goroutines in my gch services, ~250 for two weeks.

I'll leave it for a while with and w/o the patch on my servers to take a look fo dynamic, but this version looks already much better. At least, the error handling is fixed here