### PR TITLE
Add support of $-sign in metric names

### DIFF
--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -15,6 +15,7 @@ func unsafeString(b []byte) string {
 func GlobToRegexp(g string) string {
 	s := g
 	s = strings.ReplaceAll(s, ".", "[.]")
+	s = strings.ReplaceAll(s, "$", "[$]")
 	s = strings.ReplaceAll(s, "{", "(")
 	s = strings.ReplaceAll(s, "}", ")")
 	s = strings.ReplaceAll(s, "?", "[^.]")

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -15,6 +15,7 @@ func TestGlobToRegexp(t *testing.T) {
 		{`test.*.foo`, `test[.]([^.]*?)[.]foo`},
 		{`test.{foo,bar}`, `test[.](foo|bar)`},
 		{`test?.foo`, `test[^.][.]foo`},
+		{`test?.$foo`, `test[^.][.][$]foo`},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
This fixes #90 

- Escape `$` in metric names for `match()` function