### PR TITLE
Fix division by zero for one-point queries

### DIFF
--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -68,7 +68,10 @@ func (q *Querier) Select(selectParams *storage.SelectParams, labelsMatcher ...*l
 		return newMetricsSet(am.DisplayNames()), nil, nil
 	}
 
-	maxDataPoints := (until.Unix() - from.Unix()) / (selectParams.Step / 1000)
+	var maxDataPoints int64 = 1
+	if selectParams.Step != 0 {
+		maxDataPoints = (until.Unix() - from.Unix()) / (selectParams.Step / 1000)
+	}
 
 	fetchRequests := render.MultiFetchRequest{
 		render.TimeFrame{


### PR DESCRIPTION
Fix maxDataPoints for prometheus queries, when `Start == End && Step == 0`

Related to #88 and #95 