### PR TITLE
Add ClickHouse external data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create `/etc/graphite-clickhouse/rollup.xml` with same content as for ClickHouse
 </graphite_rollup>
 ```
 
-For complex clickhouse queries you might need to increase default query_max_size. To do that add following line to `/etc/clickhouse-server/users.xml` for the user you are using:
+For complex ClickHouse queries you might need to increase default query_max_size. To do that add following line to `/etc/clickhouse-server/users.xml` for the user you are using:
 ```xml
 <!-- Default is 262144 -->
 <max_query_size>10485760</max_query_size>
@@ -69,6 +69,8 @@ max-cpu = 1
 memory-return-interval = "0s"
 # Limit number of results from find query. Zero = unlimited
 max-metrics-in-find-answer = 0
+# Limit numbers of queried metrics per target in /render requests. Zero = unlimited
+max-metrics-per-target = 15000
 # Daemon returns empty response if query matches any of regular expressions
 # target-blacklist = ["^not_found.*"]
 # If this > 0, then once an interval daemon will return the freed memory to the OS

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ total-timeout = "500ms"
 # # regexp.Match({target-match-all}, target[0]) && regexp.Match({target-match-all}, target[1]) && ...
 # target-match-all = "regexp"
 
+[debug]
+# The directory for debug info. If set, additional info may be saved there
+directory = "/var/log/graphite-clickhouse/debug"
+directory-perm = "0755"
+# File permissions for external data dumps. Enabled only if !=0, see X-Gch-Debug-External-Data header
+# Format is octal, e.g. 0640
+external-data-perm = "0644"
+
 [[logging]]
 logger = ""
 file = "/var/log/graphite-clickhouse/graphite-clickhouse.log"
@@ -183,6 +191,22 @@ encoding = "mixed"
 encoding-time = "iso8601"
 encoding-duration = "seconds"
 ```
+
+### Special headers processing
+
+Some HTTP headers are processed specially by the service
+
+#### Request headers
+
+*Grafana headers*: `X-Dashboard-Id`, `X-Grafana-Org-Id`, and `X-Panel-Id` are logged and passed further to the ClickHouse.
+
+*Debug headers*:
+
+- `X-Gch-Debug-External-Data` - when this header is set to anything and every of `directory`, `directory-perm`, and `external-data-perm` parameters in `[debug]` is set and valid, service will save the dump of external data tables in the directory for debug output.
+
+#### Response headers
+
+- `X-Gch-Request-Id` - the current request ID.
 
 ## Run on same host with old graphite-web 0.9.x
 By default graphite-web won't connect to CLUSTER_SERVER on localhost. Cheat:

--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -130,8 +130,16 @@ func (h *Handler) ServeTags(w http.ResponseWriter, r *http.Request) {
 		queryLimit,
 	)
 
-	body, err := clickhouse.Query(scope.WithTable(r.Context(), h.config.ClickHouse.TaggedTable), h.config.ClickHouse.Url, sql,
-		clickhouse.Options{Timeout: h.config.ClickHouse.TreeTimeout.Value(), ConnectTimeout: h.config.ClickHouse.ConnectTimeout.Value()})
+	body, err := clickhouse.Query(
+		scope.WithTable(r.Context(), h.config.ClickHouse.TaggedTable),
+		h.config.ClickHouse.Url,
+		sql,
+		clickhouse.Options{
+			Timeout:        h.config.ClickHouse.TreeTimeout.Value(),
+			ConnectTimeout: h.config.ClickHouse.ConnectTimeout.Value(),
+		},
+		nil,
+	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -228,8 +236,16 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 		limit,
 	)
 
-	body, err := clickhouse.Query(scope.WithTable(r.Context(), h.config.ClickHouse.TaggedTable), h.config.ClickHouse.Url, sql,
-		clickhouse.Options{Timeout: h.config.ClickHouse.IndexTimeout.Value(), ConnectTimeout: h.config.ClickHouse.ConnectTimeout.Value()})
+	body, err := clickhouse.Query(
+		scope.WithTable(r.Context(), h.config.ClickHouse.TaggedTable),
+		h.config.ClickHouse.Url,
+		sql,
+		clickhouse.Options{
+			Timeout:        h.config.ClickHouse.IndexTimeout.Value(),
+			ConnectTimeout: h.config.ClickHouse.ConnectTimeout.Value(),
+		},
+		nil,
+	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,35 @@ func (d *Duration) MarshalText() ([]byte, error) {
 // Value return time.Duration value
 func (d *Duration) Value() time.Duration {
 	return d.Duration
+}
+
+// FileMode wrapper os.FileMode for TOML
+type FileMode struct {
+	os.FileMode
+}
+
+var _ toml.TextMarshaler = &FileMode{}
+
+// UnmarshalText from TOML
+func (f *FileMode) UnmarshalText(text []byte) error {
+	var err error
+	var mode uint64
+	mode, err = strconv.ParseUint(string(text), 8, 32)
+	if err != nil {
+		return err
+	}
+	f.FileMode = os.FileMode(mode)
+	return nil
+}
+
+// MarshalText encode text with TOML format
+func (f *FileMode) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("0%o", f.FileMode)), nil
+}
+
+// Value return time.Duration value
+func (f *FileMode) Value() os.FileMode {
+	return f.FileMode
 }
 
 type Common struct {
@@ -129,6 +159,16 @@ type DataTable struct {
 	Rollup                 *rollup.Rollup  `toml:"-" json:"rollup-conf"`
 }
 
+// Debug contains debugging configuration
+type Debug struct {
+	// The directory for additional debug info
+	Directory     string    `toml:"directory" json:"directory"`
+	DirectoryPerm *FileMode `toml:"directory-perm" json:"directory-perm"`
+	// If ExternalDataPerm > 0 and X-Gch-Debug-Ext-Data HTTP header is set, the external data used in the query
+	// will be saved in the DebugDir directory
+	ExternalDataPerm *FileMode `toml:"external-data-perm" json:"external-data-perm"`
+}
+
 // Config ...
 type Config struct {
 	Common     Common             `toml:"common" json:"common"`
@@ -137,6 +177,7 @@ type Config struct {
 	Tags       Tags               `toml:"tags" json:"tags"`
 	Carbonlink Carbonlink         `toml:"carbonlink" json:"carbonlink"`
 	Prometheus Prometheus         `toml:"prometheus" json:"prometheus"`
+	Debug      Debug              `toml:"debug" json:"debug"`
 	Logging    []zapwriter.Config `toml:"logging" json:"logging"`
 }
 
@@ -191,6 +232,11 @@ func New() *Config {
 		Prometheus: Prometheus{
 			ExternalURLRaw: "",
 			PageTitle:      "Prometheus Time Series Collection and Processing Server",
+		},
+		Debug: Debug{
+			Directory:        "",
+			DirectoryPerm:    &FileMode{FileMode: 0755},
+			ExternalDataPerm: &FileMode{FileMode: 0},
 		},
 		Logging: nil,
 	}
@@ -259,6 +305,19 @@ func ReadConfig(filename string) (*Config, error) {
 
 	if err := zapwriter.CheckConfig(cfg.Logging, nil); err != nil {
 		return nil, err
+	}
+
+	// Check if debug directory exists or could be created
+	if cfg.Debug.Directory != "" {
+		info, err := os.Stat(cfg.Debug.Directory)
+		if os.IsNotExist(err) {
+			err := os.MkdirAll(cfg.Debug.Directory, os.ModeDir|cfg.Debug.DirectoryPerm.FileMode)
+			if err != nil {
+				return nil, err
+			}
+		} else if !info.IsDir() {
+			return nil, fmt.Errorf("the file for external data debug dumps exists and is not a directory: %v", cfg.Debug.Directory)
+		}
 	}
 
 	if cfg.ClickHouse.DataTableLegacy != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type Common struct {
 	PprofListen            string           `toml:"pprof-listen" json:"pprof-listen"`
 	MaxCPU                 int              `toml:"max-cpu" json:"max-cpu"`
 	MaxMetricsInFindAnswer int              `toml:"max-metrics-in-find-answer" json:"max-metrics-in-find-answer"` //zero means infinite
+	MaxMetricsPerTarget    int              `toml:"max-metrics-per-target" json:"max-metrics-per-target"`
 	TargetBlacklist        []string         `toml:"target-blacklist" json:"target-blacklist"`
 	Blacklist              []*regexp.Regexp `toml:"-" json:"-"` // compiled TargetBlacklist
 	MemoryReturnInterval   *Duration        `toml:"memory-return-interval" json:"memory-return-interval"`
@@ -194,6 +195,7 @@ func New() *Config {
 			// MetricEndpoint: MetricEndpointLocal,
 			MaxCPU:                 1,
 			MaxMetricsInFindAnswer: 0,
+			MaxMetricsPerTarget:    15000, // This is arbitrary value to protect CH from overload
 			MemoryReturnInterval:   &Duration{},
 		},
 		ClickHouse: ClickHouse{

--- a/finder/base.go
+++ b/finder/base.go
@@ -43,6 +43,7 @@ func (b *BaseFinder) Execute(ctx context.Context, query string, from int64, unti
 		b.url,
 		fmt.Sprintf("SELECT Path FROM %s WHERE %s GROUP BY Path", b.table, w),
 		b.opts,
+		nil,
 	)
 
 	return

--- a/finder/date.go
+++ b/finder/date.go
@@ -43,10 +43,9 @@ func (b *DateFinder) Execute(ctx context.Context, query string, from int64, unti
 		b.body, err = clickhouse.Query(
 			scope.WithTable(ctx, b.table),
 			b.url,
-			fmt.Sprintf(
-				`SELECT Path FROM %s PREWHERE (%s) WHERE %s GROUP BY Path`,
-				b.table, dateWhere, w),
+			fmt.Sprintf(`SELECT Path FROM %s PREWHERE (%s) WHERE %s GROUP BY Path`, b.table, dateWhere, w),
 			b.opts,
+			nil,
 		)
 	} else {
 		b.body, err = clickhouse.Query(
@@ -54,6 +53,7 @@ func (b *DateFinder) Execute(ctx context.Context, query string, from int64, unti
 			b.url,
 			fmt.Sprintf(`SELECT DISTINCT Path FROM %s PREWHERE (%s) WHERE (%s)`, b.table, dateWhere, w),
 			b.opts,
+			nil,
 		)
 	}
 

--- a/finder/date_reverse.go
+++ b/finder/date_reverse.go
@@ -38,10 +38,9 @@ func (f *DateFinderV3) Execute(ctx context.Context, query string, from int64, un
 	f.body, err = clickhouse.Query(
 		scope.WithTable(ctx, f.table),
 		f.url,
-		fmt.Sprintf(
-			`SELECT Path FROM %s WHERE (%s) AND (%s) GROUP BY Path`,
-			f.table, dateWhere, w),
+		fmt.Sprintf(`SELECT Path FROM %s WHERE (%s) AND (%s) GROUP BY Path`, f.table, dateWhere, w),
 		f.opts,
+		nil,
 	)
 
 	return

--- a/finder/index.go
+++ b/finder/index.go
@@ -97,6 +97,7 @@ func (idx *IndexFinder) Execute(ctx context.Context, query string, from int64, u
 		idx.url,
 		fmt.Sprintf("SELECT Path FROM %s WHERE %s GROUP BY Path", idx.table, w),
 		idx.opts,
+		nil,
 	)
 
 	return

--- a/finder/tag.go
+++ b/finder/tag.go
@@ -219,7 +219,7 @@ func (t *TagFinder) Execute(ctx context.Context, query string, from int64, until
 	}
 
 	if sql != "" {
-		t.body, err = clickhouse.Query(scope.WithTable(ctx, t.table), t.url, sql, t.opts)
+		t.body, err = clickhouse.Query(scope.WithTable(ctx, t.table), t.url, sql, t.opts, nil)
 	}
 
 	return err

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -242,7 +242,7 @@ func (t *TaggedFinder) ExecutePrepared(ctx context.Context, terms []TaggedTerm, 
 	)
 
 	sql := fmt.Sprintf("SELECT Path FROM %s %s %s GROUP BY Path", t.table, pw.PreWhereSQL(), w.SQL())
-	t.body, err = clickhouse.Query(scope.WithTable(ctx, t.table), t.url, sql, t.opts)
+	t.body, err = clickhouse.Query(scope.WithTable(ctx, t.table), t.url, sql, t.opts, nil)
 	return err
 }
 

--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -63,6 +63,8 @@ func Handler(handler http.Handler) http.Handler {
 
 		r = scope.HttpRequest(r)
 
+		w.Header().Add("X-Gch-Request-ID", scope.RequestID(r.Context()))
+
 		start := time.Now()
 		handler.ServeHTTP(writer, r)
 		d := time.Since(start)

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -131,23 +131,28 @@ func formatSQL(q string) string {
 	return strings.Join(s, " ")
 }
 
-func Query(ctx context.Context, dsn string, query string, opts Options) ([]byte, error) {
-	return Post(ctx, dsn, query, nil, opts)
+func Query(ctx context.Context, dsn string, query string, opts Options, extData *ExternalData) ([]byte, error) {
+	return Post(ctx, dsn, query, nil, opts, extData)
 }
 
-func Post(ctx context.Context, dsn string, query string, postBody io.Reader, opts Options) ([]byte, error) {
-	return do(ctx, dsn, query, postBody, false, opts)
+func Post(ctx context.Context, dsn string, query string, postBody io.Reader, opts Options, extData *ExternalData) ([]byte, error) {
+	return do(ctx, dsn, query, postBody, false, opts, extData)
 }
 
-func PostGzip(ctx context.Context, dsn string, query string, postBody io.Reader, opts Options) ([]byte, error) {
-	return do(ctx, dsn, query, postBody, true, opts)
+func PostGzip(ctx context.Context, dsn string, query string, postBody io.Reader, opts Options, extData *ExternalData) ([]byte, error) {
+	return do(ctx, dsn, query, postBody, true, opts, extData)
 }
 
-func Reader(ctx context.Context, dsn string, query string, opts Options) (io.ReadCloser, error) {
-	return reader(ctx, dsn, query, nil, false, opts)
+func Reader(ctx context.Context, dsn string, query string, opts Options, extData *ExternalData) (io.ReadCloser, error) {
+	return reader(ctx, dsn, query, nil, false, opts, extData)
 }
 
-func reader(ctx context.Context, dsn string, query string, postBody io.Reader, gzip bool, opts Options) (bodyReader io.ReadCloser, err error) {
+func reader(ctx context.Context, dsn string, query string, postBody io.Reader, gzip bool, opts Options, extData *ExternalData) (bodyReader io.ReadCloser, err error) {
+	if postBody != nil && extData != nil {
+		err = fmt.Errorf("postBody and extData could not be passed in one request")
+		return
+	}
+
 	var chQueryID string
 
 	start := time.Now()
@@ -180,10 +185,19 @@ func reader(ctx context.Context, dsn string, query string, postBody io.Reader, g
 	q.Set("query_id", fmt.Sprintf("%s::%s", requestID, queryID))
 	p.RawQuery = q.Encode()
 
+	var contentHeader string
 	if postBody != nil {
 		q := p.Query()
 		q.Set("query", query)
 		p.RawQuery = q.Encode()
+	} else if extData != nil {
+		q := p.Query()
+		q.Set("query", query)
+		p.RawQuery = q.Encode()
+		postBody, contentHeader, err = extData.buildBody(p)
+		if err != nil {
+			return
+		}
 	} else {
 		postBody = strings.NewReader(query)
 	}
@@ -196,6 +210,9 @@ func reader(ctx context.Context, dsn string, query string, postBody io.Reader, g
 	}
 
 	req.Header.Add("User-Agent", scope.ClickhouseUserAgent(ctx))
+	if contentHeader != "" {
+		req.Header.Add("Content-Type", contentHeader)
+	}
 
 	if gzip {
 		req.Header.Add("Content-Encoding", "gzip")
@@ -241,8 +258,8 @@ func reader(ctx context.Context, dsn string, query string, postBody io.Reader, g
 	return
 }
 
-func do(ctx context.Context, dsn string, query string, postBody io.Reader, gzip bool, opts Options) ([]byte, error) {
-	bodyReader, err := reader(ctx, dsn, query, postBody, gzip, opts)
+func do(ctx context.Context, dsn string, query string, postBody io.Reader, gzip bool, opts Options, extData *ExternalData) ([]byte, error) {
+	bodyReader, err := reader(ctx, dsn, query, postBody, gzip, opts, extData)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -163,7 +163,7 @@ func reader(ctx context.Context, dsn string, query string, postBody io.Reader, g
 	if len(queryForLogger) > 500 {
 		queryForLogger = queryForLogger[:395] + "<...>" + queryForLogger[len(queryForLogger)-100:]
 	}
-	logger := scope.Logger(ctx).With(zap.String("query", formatSQL(queryForLogger)), zap.String("request_id", requestID))
+	logger := scope.Logger(ctx).With(zap.String("query", formatSQL(queryForLogger)))
 
 	defer func() {
 		// fmt.Println(time.Since(start), formatSQL(queryForLogger))

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -198,6 +198,10 @@ func reader(ctx context.Context, dsn string, query string, postBody io.Reader, g
 		if err != nil {
 			return
 		}
+		err = extData.debugDump(ctx)
+		if err != nil {
+			logger.Warn("external-data", zap.Error(err))
+		}
 	} else {
 		postBody = strings.NewReader(query)
 	}

--- a/helper/clickhouse/external-data.go
+++ b/helper/clickhouse/external-data.go
@@ -1,0 +1,74 @@
+package clickhouse
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/url"
+	"strings"
+)
+
+// ExternalData is a structure to use ClickHouse feature that creates a temporary table per query
+type ExternalTable struct {
+	// Table nama
+	Name    string
+	Columns []Column
+	// ClickHouse input/output format
+	Format string
+	Data   []byte
+}
+
+// Column is a pair of Name and Type for temporary
+type Column struct {
+	Name string
+	// ClickHouse data type
+	Type string
+}
+
+func (c *Column) String() string {
+	return c.Name + " " + c.Type
+}
+
+type ExternalData struct {
+	Tables []ExternalTable
+}
+
+func NewExternalData(tables ...ExternalTable) *ExternalData {
+	return &ExternalData{Tables: tables}
+}
+
+// buildBody returns multiform body, content type header and error
+func (e *ExternalData) buildBody(u *url.URL) (*bytes.Buffer, string, error) {
+	body := new(bytes.Buffer)
+	header := ""
+	writer := multipart.NewWriter(body)
+	for _, t := range e.Tables {
+		part, err := writer.CreateFormFile(t.Name, t.Name)
+		if err != nil {
+			return nil, header, err
+		}
+
+		// Send each table in separated form
+		_, err = part.Write(t.Data)
+		if err != nil {
+			return nil, header, err
+		}
+
+		// Set name_format and name_structure for the table
+		q := u.Query()
+		if t.Format != "" {
+			q.Set(t.Name+"_format", t.Format)
+		}
+		structure := make([]string, 0, len(t.Columns))
+		for _, c := range t.Columns {
+			structure = append(structure, c.String())
+		}
+		q.Set(t.Name+"_structure", strings.Join(structure, ","))
+		u.RawQuery = q.Encode()
+	}
+	err := writer.Close()
+	if err != nil {
+		return nil, header, err
+	}
+	header = writer.FormDataContentType()
+	return body, header, nil
+}

--- a/helper/rollup/remote.go
+++ b/helper/rollup/remote.go
@@ -133,6 +133,7 @@ func remoteLoad(addr string, table string) (*Rules, error) {
 		addr,
 		query,
 		clickhouse.Options{Timeout: 10 * time.Second, ConnectTimeout: 10 * time.Second},
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/index/index.go
+++ b/index/index.go
@@ -31,9 +31,12 @@ func New(config *config.Config, ctx context.Context) (*Index, error) {
 		reader, err = clickhouse.Reader(
 			scope.WithTable(ctx, config.ClickHouse.IndexTable),
 			config.ClickHouse.Url,
-			fmt.Sprintf("SELECT Path FROM %s WHERE Date = '%s' AND Level >= %d AND Level < %d GROUP BY Path",
-				config.ClickHouse.IndexTable, finder.DefaultTreeDate, finder.TreeLevelOffset, finder.ReverseTreeLevelOffset),
+			fmt.Sprintf(
+				"SELECT Path FROM %s WHERE Date = '%s' AND Level >= %d AND Level < %d GROUP BY Path",
+				config.ClickHouse.IndexTable, finder.DefaultTreeDate, finder.TreeLevelOffset, finder.ReverseTreeLevelOffset,
+			),
 			opts,
+			nil,
 		)
 	} else {
 		opts := clickhouse.Options{
@@ -45,6 +48,7 @@ func New(config *config.Config, ctx context.Context) (*Index, error) {
 			config.ClickHouse.Url,
 			fmt.Sprintf("SELECT Path FROM %s GROUP BY Path", config.ClickHouse.TreeTable),
 			opts,
+			nil,
 		)
 	}
 

--- a/pkg/scope/http_request.go
+++ b/pkg/scope/http_request.go
@@ -28,6 +28,10 @@ func HttpRequest(r *http.Request) *http.Request {
 	ctx := r.Context()
 	ctx = WithRequestID(ctx, requestID)
 
+	if d := r.Header.Get("X-Gch-Debug-External-Data"); d != "" {
+		ctx = WithDebug(ctx, "ExternalData")
+	}
+
 	for _, h := range passHeaders {
 		hv := r.Header.Get(h)
 		if hv != "" {

--- a/pkg/scope/key.go
+++ b/pkg/scope/key.go
@@ -21,6 +21,14 @@ func String(ctx context.Context, key string) string {
 	return ""
 }
 
+// Bool returns the true if particular key of the context is set
+func Bool(ctx context.Context, key string) bool {
+	if _, ok := ctx.Value(scopeKey(key)).(bool); ok {
+		return true
+	}
+	return false
+}
+
 // WithRequestID ...
 func WithRequestID(ctx context.Context, requestID string) context.Context {
 	return With(ctx, "requestID", requestID)
@@ -39,6 +47,16 @@ func WithTable(ctx context.Context, table string) context.Context {
 // Table ...
 func Table(ctx context.Context) string {
 	return String(ctx, "table")
+}
+
+// WithDebug returns the context with debug-name
+func WithDebug(ctx context.Context, name string) context.Context {
+	return With(ctx, "debug-"+name, true)
+}
+
+// Debug returns true if debug-name should be enabled
+func Debug(ctx context.Context, name string) bool {
+	return Bool(ctx, "debug-"+name)
 }
 
 // ClickhouseUserAgent ...

--- a/pkg/scope/logger.go
+++ b/pkg/scope/logger.go
@@ -14,6 +14,7 @@ func Logger(ctx context.Context) *zap.Logger {
 	if logger != nil {
 		if zl, ok := logger.(*zap.Logger); ok {
 			zapLogger = zl
+			return zapLogger
 		}
 	}
 	if zapLogger == nil {

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -101,6 +101,10 @@ func In(field string, list []string) string {
 	return buf.String()
 }
 
+func InTable(field string, table string) string {
+	return fmt.Sprintf("%s in %s", field, table)
+}
+
 func DateBetween(field string, from time.Time, until time.Time) string {
 	return fmt.Sprintf(
 		"%s >='%s' AND %s <= '%s'",

--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -75,7 +75,6 @@ func NewHandler(config *config.Config) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := scope.Logger(r.Context()).Named("prometheus")
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
-	w.Header().Add("X-Gch-Request-ID", scope.RequestID(r.Context()))
 	if strings.HasSuffix(r.URL.Path, "/read") {
 		h.read(w, r)
 		return

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -51,8 +51,16 @@ func (q *Querier) LabelValues(label string) ([]string, storage.Warnings, error) 
 		w.SQL(),
 	)
 
-	body, err := clickhouse.Query(scope.WithTable(q.ctx, q.config.ClickHouse.TaggedTable), q.config.ClickHouse.Url, sql,
-		clickhouse.Options{Timeout: q.config.ClickHouse.IndexTimeout.Value(), ConnectTimeout: q.config.ClickHouse.ConnectTimeout.Value()})
+	body, err := clickhouse.Query(
+		scope.WithTable(q.ctx, q.config.ClickHouse.TaggedTable),
+		q.config.ClickHouse.Url,
+		sql,
+		clickhouse.Options{
+			Timeout:        q.config.ClickHouse.IndexTimeout.Value(),
+			ConnectTimeout: q.config.ClickHouse.ConnectTimeout.Value(),
+		},
+		nil,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,8 +84,16 @@ func (q *Querier) LabelNames() ([]string, storage.Warnings, error) {
 		w.SQL(),
 	)
 
-	body, err := clickhouse.Query(scope.WithTable(q.ctx, q.config.ClickHouse.TaggedTable), q.config.ClickHouse.Url, sql,
-		clickhouse.Options{Timeout: q.config.ClickHouse.IndexTimeout.Value(), ConnectTimeout: q.config.ClickHouse.ConnectTimeout.Value()})
+	body, err := clickhouse.Query(
+		scope.WithTable(q.ctx, q.config.ClickHouse.TaggedTable),
+		q.config.ClickHouse.Url,
+		sql,
+		clickhouse.Options{
+			Timeout:        q.config.ClickHouse.IndexTimeout.Value(),
+			ConnectTimeout: q.config.ClickHouse.ConnectTimeout.Value(),
+		},
+		nil,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/render/handler.go
+++ b/render/handler.go
@@ -34,7 +34,6 @@ func NewHandler(config *config.Config) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := scope.Logger(r.Context()).Named("render")
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
-	w.Header().Add("X-Gch-Request-ID", scope.RequestID(r.Context()))
 
 	var prefix string
 	var err error

--- a/render/query.go
+++ b/render/query.go
@@ -256,6 +256,7 @@ func (r *Reply) getDataAggregated(ctx context.Context, cfg *config.Config, tf Ti
 			Data:   tableBody,
 		}
 		extData := clickhouse.NewExternalData(tempTable)
+		extData.SetDebug(cfg.Debug.Directory, cfg.Debug.ExternalDataPerm.FileMode)
 		wr.And(where.InTable("Path", tempTable.Name))
 
 		wr.And(where.TimestampBetween("Time", from, until))
@@ -354,6 +355,7 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 		Data:   tableBody,
 	}
 	extData := clickhouse.NewExternalData(tempTable)
+	extData.SetDebug(cfg.Debug.Directory, cfg.Debug.ExternalDataPerm.FileMode)
 
 	pw := where.New()
 	pw.And(where.DateBetween("Date", time.Unix(tf.From, 0), time.Unix(until, 0)))

--- a/render/query.go
+++ b/render/query.go
@@ -260,7 +260,11 @@ func (r *Reply) getDataAggregated(ctx context.Context, cfg *config.Config, tf Ti
 				scope.WithTable(ctx, targets.pointsTable),
 				cfg.ClickHouse.Url,
 				query,
-				clickhouse.Options{Timeout: cfg.ClickHouse.DataTimeout.Value(), ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value()},
+				clickhouse.Options{
+					Timeout:        cfg.ClickHouse.DataTimeout.Value(),
+					ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value(),
+				},
+				nil,
 			)
 			if err != nil {
 				logger.Error("reader", zap.Error(err))
@@ -345,7 +349,11 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 		scope.WithTable(ctx, targets.pointsTable),
 		cfg.ClickHouse.Url,
 		query,
-		clickhouse.Options{Timeout: cfg.ClickHouse.DataTimeout.Value(), ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value()},
+		clickhouse.Options{
+			Timeout:        cfg.ClickHouse.DataTimeout.Value(),
+			ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value(),
+		},
+		nil,
 	)
 
 	if err != nil {

--- a/tagger/tagger.go
+++ b/tagger/tagger.go
@@ -124,7 +124,11 @@ func Make(cfg *config.Config) error {
 					i,
 					extraWhere,
 				),
-				clickhouse.Options{Timeout: cfg.ClickHouse.IndexTimeout.Value(), ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value()},
+				clickhouse.Options{
+					Timeout:        cfg.ClickHouse.IndexTimeout.Value(),
+					ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value(),
+				},
+				nil,
 			)
 			if err != nil {
 				return err
@@ -345,7 +349,11 @@ func Make(cfg *config.Config) error {
 			cfg.ClickHouse.Url,
 			fmt.Sprintf("INSERT INTO %s (Date,Version,Level,Path,IsLeaf,Tags,Tag1) FORMAT RowBinary", cfg.ClickHouse.TagTable),
 			outBuf,
-			clickhouse.Options{Timeout: cfg.ClickHouse.IndexTimeout.Value(), ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value()},
+			clickhouse.Options{
+				Timeout:        cfg.ClickHouse.IndexTimeout.Value(),
+				ConnectTimeout: cfg.ClickHouse.ConnectTimeout.Value(),
+			},
+			nil,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This should fix #59

Here are benchmark results for old and new logic grouped by the number of metrics returned by the finder:

```
# request.sh:
# curl "http://localhost:8080/render?target=sum($(series "$1"))&from=-24h&until=now&format=json&maxDataPoints=30"

$ for test in 4 320 1432 2366 5876 10151 35957; do hyperfine -w 2 -r 10 "./request.sh $test"; done
Benchmark #1: ./request.sh 4
# old
  Time (mean ± σ):     233.9 ms ±  24.9 ms    [User: 28.6 ms, System: 18.7 ms]
  Range (min … max):   194.1 ms … 264.3 ms    10 runs
# new
  Time (mean ± σ):     215.8 ms ±  19.9 ms    [User: 23.8 ms, System: 15.2 ms]
  Range (min … max):   176.8 ms … 245.4 ms    10 runs

----

Benchmark #1: ./request.sh 320
# old
  Time (mean ± σ):      1.715 s ±  0.756 s    [User: 7.7 ms, System: 4.7 ms]
  Range (min … max):    0.756 s …  3.185 s    10 runs
# new
  Time (mean ± σ):     728.5 ms ±  71.9 ms    [User: 7.3 ms, System: 4.9 ms]
  Range (min … max):   655.3 ms … 871.9 ms    10 runs

----

Benchmark #1: ./request.sh 1432
# old
  Time (mean ± σ):      2.585 s ±  0.521 s    [User: 7.9 ms, System: 2.6 ms]
  Range (min … max):    2.259 s …  4.023 s    10 runs
# new
  Time (mean ± σ):      2.070 s ±  0.267 s    [User: 5.3 ms, System: 4.5 ms]
  Range (min … max):    1.796 s …  2.778 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

----

Benchmark #1: ./request.sh 2366
# old
  Time (mean ± σ):      3.847 s ±  1.719 s    [User: 6.4 ms, System: 3.2 ms]
  Range (min … max):    2.699 s …  7.413 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
# new
  Time (mean ± σ):      2.745 s ±  0.793 s    [User: 5.6 ms, System: 3.8 ms]
  Range (min … max):    2.264 s …  4.952 s    10 runs

----

Benchmark #1: ./request.sh 5876
# old
  Time (mean ± σ):      6.365 s ±  2.375 s    [User: 5.3 ms, System: 5.0 ms]
  Range (min … max):    4.547 s … 11.924 s    10 runs
# new
  Time (mean ± σ):      4.984 s ±  2.903 s    [User: 7.3 ms, System: 2.7 ms]
  Range (min … max):    3.356 s … 12.362 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (12.362 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

----

Benchmark #1: ./request.sh 10151
# old
  Time (mean ± σ):     19.780 s ±  4.474 s    [User: 8.7 ms, System: 5.8 ms]
  Range (min … max):   16.728 s … 31.647 s    10 runs
# new
  Time (mean ± σ):     11.199 s ±  3.898 s    [User: 5.7 ms, System: 5.7 ms]
  Range (min … max):    8.273 s … 19.967 s    10 runs

----

Benchmark #1: ./request.sh 35957 # is failed because of too long queries, more than 512k characters
# old
  Time (mean ± σ):     725.6 ms ± 142.7 ms    [User: 14.4 ms, System: 17.1 ms]
  Range (min … max):   548.4 ms … 1021.2 ms    10 runs
# new
  Time (mean ± σ):     13.846 s ±  5.729 s    [User: 6.7 ms, System: 5.0 ms]
  Range (min … max):   11.167 s … 30.026 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```