### PR TITLE
External data fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ max-cpu = 1
 memory-return-interval = "0s"
 # Limit number of results from find query. Zero = unlimited
 max-metrics-in-find-answer = 0
-# Limit numbers of queried metrics per target in /render requests. Zero = unlimited
+# Limit numbers of queried metrics per target in /render requests. Zero or negative are unlimited
 max-metrics-per-target = 15000
 # Daemon returns empty response if query matches any of regular expressions
 # target-blacklist = ["^not_found.*"]

--- a/render/query.go
+++ b/render/query.go
@@ -56,6 +56,10 @@ type Targets struct {
 type MultiFetchRequest map[TimeFrame]*Targets
 
 func (m *MultiFetchRequest) checkMetricsLimitExceeded(num int) error {
+	if num <= 0 {
+		// zero or negative means unlimited
+		return nil
+	}
 	for _, t := range *m {
 		if num < t.AM.Len() {
 			return fmt.Errorf("metrics limit exceeded: %v < %v", num, t.AM.Len())


### PR DESCRIPTION
There are some bugs in the recent commit:

- No unlimited values for `max-metrics-per-target`
- SetDebug had the wrong condition for a non-debug case, both directory and files permission must be set