### PR TITLE
Add FloorToMultiplier, make data fetching inclusive for until

### DIFF
--- a/pkg/dry/math.go
+++ b/pkg/dry/math.go
@@ -17,12 +17,21 @@ func Min(x, y int64) int64 {
 }
 
 // CeilToMultiplier returns the integer greater or equal to x and multiplier m product.
-// Works only with x >= 0 and m > 0. It returns 0 with wother values.
+// Works only with x >= 0 and m > 0. It returns 0 with other values.
 func CeilToMultiplier(x, m int64) int64 {
 	if x <= 0 || m <= 0 {
 		return int64(0)
 	}
 	return ((x + m - 1) / m) * m
+}
+
+// FloorToMultiplier returns the integer less or equal to x and multiplier m product.
+// Works only with x >= 0 and m > 0. It returns 0 with other values.
+func FloorToMultiplier(x, m int64) int64 {
+	if x <= 0 || m <= 0 {
+		return int64(0)
+	}
+	return x / m * m
 }
 
 // GCD returns the absolute greatest common divisor calculated via Euclidean algorithm

--- a/pkg/dry/math_test.go
+++ b/pkg/dry/math_test.go
@@ -25,10 +25,23 @@ func TestMin(t *testing.T) {
 func TestCeilToMultiplier(t *testing.T) {
 	assert := assert.New(t)
 
+	assert.Equal(int64(0), CeilToMultiplier(0, -1))
+	assert.Equal(int64(0), CeilToMultiplier(1, 0))
 	assert.Equal(int64(0), CeilToMultiplier(1, -1))
 	assert.Equal(int64(2), CeilToMultiplier(1, 2))
 	assert.Equal(int64(6), CeilToMultiplier(4, 3))
 	assert.Equal(int64(6), CeilToMultiplier(6, 3))
+}
+
+func TestFloorToMultiplier(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(int64(0), FloorToMultiplier(0, -1))
+	assert.Equal(int64(0), FloorToMultiplier(1, 0))
+	assert.Equal(int64(0), FloorToMultiplier(1, -1))
+	assert.Equal(int64(0), FloorToMultiplier(1, 2))
+	assert.Equal(int64(3), FloorToMultiplier(4, 3))
+	assert.Equal(int64(6), FloorToMultiplier(6, 3))
 }
 
 func TestGCD(t *testing.T) {

--- a/render/query.go
+++ b/render/query.go
@@ -258,7 +258,7 @@ func (r *Reply) getDataAggregated(ctx context.Context, cfg *config.Config, tf Ti
 
 	for agg, tableBody := range metricsAggregation {
 		from := dry.CeilToMultiplier(tf.From, step)
-		until := dry.CeilToMultiplier(tf.Until, step) - 1
+		until := dry.FloorToMultiplier(tf.Until, step) + step - 1
 		pw := where.New()
 		pw.And(where.DateBetween("Date", time.Unix(from, 0), time.Unix(until, 0)))
 
@@ -359,7 +359,7 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 
 		steps[m] = step
 	}
-	until := dry.CeilToMultiplier(tf.Until, maxStep) - 1
+	until := dry.FloorToMultiplier(tf.Until, maxStep) + maxStep - 1
 
 	tableBody := []byte(strings.Join(metricList, "\n"))
 	tempTable := clickhouse.ExternalTable{


### PR DESCRIPTION
This fixes #107, makes ClickHouse data fetching query inclusive for `until`