### PR TITLE
Use 60s as default step in prometheus Querier implementation when using internal-aggregation 

### DIFF
--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -68,10 +68,12 @@ func (q *Querier) Select(selectParams *storage.SelectParams, labelsMatcher ...*l
 		return newMetricsSet(am.DisplayNames()), nil, nil
 	}
 
-	var maxDataPoints int64 = 1
+	var step int64 = 60000
 	if selectParams.Step != 0 {
-		maxDataPoints = (until.Unix() - from.Unix()) / (selectParams.Step / 1000)
+		step = selectParams.Step
 	}
+
+	maxDataPoints := (until.Unix() - from.Unix()) / (step / 1000)
 
 	fetchRequests := render.MultiFetchRequest{
 		render.TimeFrame{


### PR DESCRIPTION
Basically subj.

Currently, using internal-aggregation, limit on max points queried is calculated based on provided step. For the `/api/v1/query` requests there is no such parameter, so default limit in 1 point is used.

This causes any aggregate function to behave incorrectly. For example

* `min_over_time(graphite{target="some.metric"}[20m])`
* `avg_over_time(graphite{target="some.metric"}[20m])` 
* `max_over_time(graphite{target="some.metric"}[20m])` 

will always return the same result for all metrics, since one-valued vector will be fetched from ch.

Another example is function `delta(graphite{target="some.metric"}[20m:1m])`, which will always return 0, since it'll substract the only one point in vector from itself.

I propose to use native to graphite 60s interval in case there was none given.