### PR TITLE
Tag value containing '=' is cut of

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -225,10 +225,10 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 
 	var valueSQL string
 	if len(usedTags) == 0 {
-		valueSQL = "splitByChar('=', Tag1)[2] AS value"
+		valueSQL = "substr(Tag1, " + (len(tag)+2) + ") AS value"
 		wr.And(where.HasPrefix("Tag1", tag+"="+valuePrefix))
 	} else {
-		valueSQL = "splitByChar('=', arrayJoin(Tags))[2] AS value"
+		valueSQL = "substr(arrayJoin(Tags), " + (len(tag)+2) + ") AS value"
 		wr.And(where.HasPrefix("arrayJoin(Tags)", tag+"="+valuePrefix))
 	}
 

--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -225,10 +225,10 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 
 	var valueSQL string
 	if len(usedTags) == 0 {
-		valueSQL = "substr(Tag1, " + (len(tag)+2) + ") AS value"
+		valueSQL = fmt.Sprintf("substr(Tag1, %d) AS value", len(tag)+2)
 		wr.And(where.HasPrefix("Tag1", tag+"="+valuePrefix))
 	} else {
-		valueSQL = "substr(arrayJoin(Tags), " + (len(tag)+2) + ") AS value"
+		valueSQL = fmt.Sprintf("substr(arrayJoin(Tags), %d) AS value", len(tag)+2)
 		wr.And(where.HasPrefix("arrayJoin(Tags)", tag+"="+valuePrefix))
 	}
 


### PR DESCRIPTION
When doing a `tag_values()` that would result in a value that contains `=`, the value seems to be cut off from that point in the results.

Found the problem in the resulting query, this fix tries to workaround (not tested the GO code).