### PR TITLE
Add LF to the last line of external data

### DIFF
--- a/render/query.go
+++ b/render/query.go
@@ -242,9 +242,9 @@ func (r *Reply) getDataAggregated(ctx context.Context, cfg *config.Config, tf Ti
 		newStep, agg := targets.rollupObj.Lookup(m, uint32(age))
 		step = r.cStep.calculateUnsafe(step, int64(newStep))
 		if mm, ok := bodyAggregation[agg.Name()]; ok {
-			bodyAggregation[agg.Name()] = append(mm, []byte("\n"+m)...)
+			bodyAggregation[agg.Name()] = append(mm, []byte(m+"\n")...)
 		} else {
-			bodyAggregation[agg.Name()] = []byte(m)
+			bodyAggregation[agg.Name()] = []byte(m + "\n")
 		}
 
 		if targets.isReverse {
@@ -384,7 +384,7 @@ func (r *Reply) getDataUnaggregated(ctx context.Context, cfg *config.Config, tf 
 	}
 	until := dry.FloorToMultiplier(tf.Until, maxStep) + maxStep - 1
 
-	tableBody := []byte(strings.Join(metricList, "\n"))
+	tableBody := []byte(strings.Join(metricList, "\n") + "\n")
 	tempTable := clickhouse.ExternalTable{
 		Name: "metrics_list",
 		Columns: []clickhouse.Column{{


### PR DESCRIPTION
According to https://github.com/ClickHouse/ClickHouse/issues/21953 each line including the last one in external data forms must have `\n` at the end.