### PR TITLE
Allow tune of usage reverse/forward index

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,13 @@ index-use-daily = true
 # 2 - allow a.b*.c.d) to index table.
 # This is useful when reverse queries has bad perfomance
 index-reverse-depth = 1
-# overwrite default index-use-reverse for metrics with prefix/suffix (not used when index-use-reverse = -1)
+# overwrite default index-use-reverse for metrics with prefix/suffix/regular_expression checks against target (not used when index-use-reverse = -1)
 #index-reverses = [
 #    { suffix = ".p99", reverse = 2 },
 #    { suffix = ".avg", reverse = 2 },
-#    { suffix = ".gc.gen1", reverse = 0 }
-#    { prefix = "Test.", suffix = ".cpu", reverse = 2 }
+#    { suffix = ".gc.gen1", reverse = 0 },
+#    { prefix = "Test.", suffix = ".cpu", reverse = 2 },
+#    { regex = "\\.gc\\.(heap|gen)[0-9]+$", reverse = 0 }
 #]
 index-reverses = []
 index-timeout = "1m0s"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ rollup-conf = "/etc/graphite-clickhouse/rollup.xml"
 index-table = "graphite_index"
 # Use daily data from index table. This is useful for installations with big count of short-lived series but can be slower in other cases
 index-use-daily = true
+# Allow use reverse queries with minimal depth
+# -1 - disable
+# 0 - disable if no wildcard at first level
+# 1 - allow for example a.b.c*.d and a.b*.c.d queries (default)
+# 2 - allow a.b*.c.d) to index table.
+# This is useful when reverse queries has bad perfomance
+index-reverse-depth = 1
+# overwrite default index-use-reverse for metrics with prefix/suffix (not used when index-use-reverse = -1)
+#index-reverses = [
+#    { suffix = ".p99", reverse = 2 },
+#    { suffix = ".avg", reverse = 2 },
+#    { suffix = ".gc.gen1", reverse = 0 }
+#    { prefix = "Test.", suffix = ".cpu", reverse = 2 }
+#]
+index-reverses = []
 index-timeout = "1m0s"
 
 # `tagged` table from carbon-clickhouse. Required for seriesByTag

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,12 @@ type Common struct {
 	MemoryReturnInterval   *Duration        `toml:"memory-return-interval" json:"memory-return-interval"`
 }
 
+type NValue struct {
+	Suffix string `toml:"suffix" json:"suffix"`
+	Prefix string `toml:"prefix" json:"prefix"`
+	Value  int    `toml:"reverse" json:"reverse"`
+}
+
 type ClickHouse struct {
 	Url                  string    `toml:"url" json:"url"`
 	DataTimeout          *Duration `toml:"data-timeout" json:"data-timeout"`
@@ -93,6 +99,8 @@ type ClickHouse struct {
 	DateTreeTableVersion int       `toml:"date-tree-table-version" json:"date-tree-table-version"`
 	IndexTable           string    `toml:"index-table" json:"index-table"`
 	IndexUseDaily        bool      `toml:"index-use-daily" json:"index-use-daily"`
+	IndexReverseDepth    int       `toml:"index-reverse-depth" json:"index-reverse-depth"`
+	IndexUseReverses     []NValue  `toml:"index-reverses" json:"index-reverses"`
 	IndexTimeout         *Duration `toml:"index-timeout" json:"index-timeout"`
 	TaggedTable          string    `toml:"tagged-table" json:"tagged-table"`
 	TaggedAutocompleDays int       `toml:"tagged-autocomplete-days" json:"tagged-autocomplete-days"`
@@ -208,8 +216,10 @@ func New() *Config {
 			TreeTimeout: &Duration{
 				Duration: time.Minute,
 			},
-			IndexTable:    "",
-			IndexUseDaily: true,
+			IndexTable:        "",
+			IndexUseDaily:     true,
+			IndexReverseDepth: 1,
+			IndexUseReverses:  []NValue{},
 			IndexTimeout: &Duration{
 				Duration: time.Minute,
 			},

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -43,6 +43,8 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 			config.ClickHouse.Url,
 			config.ClickHouse.IndexTable,
 			config.ClickHouse.IndexUseDaily,
+			config.ClickHouse.IndexReverseDepth,
+			config.ClickHouse.IndexUseReverses,
 			clickhouse.Options{
 				Timeout:        config.ClickHouse.IndexTimeout.Value(),
 				ConnectTimeout: config.ClickHouse.ConnectTimeout.Value(),

--- a/finder/index.go
+++ b/finder/index.go
@@ -25,13 +25,13 @@ type IndexFinder struct {
 	opts         clickhouse.Options // timeout, connectTimeout
 	dailyEnabled bool
 	reverseDepth int
-	revUse       []config.NValue
+	revUse       []*config.NValue
 	body         []byte // clickhouse response body
 	useReverse   bool
 	useDaily     bool
 }
 
-func NewIndex(url string, table string, dailyEnabled bool, reverseDepth int, reverseUse []config.NValue, opts clickhouse.Options) Finder {
+func NewIndex(url string, table string, dailyEnabled bool, reverseDepth int, reverseUse []*config.NValue, opts clickhouse.Options) Finder {
 	return &IndexFinder{
 		url:          url,
 		table:        table,
@@ -62,15 +62,15 @@ func useReverse(query string) bool {
 	return true
 }
 
-func reverseSuffixDepth(query string, defaultReverseDepth int, revUse []config.NValue) int {
+func reverseSuffixDepth(query string, defaultReverseDepth int, revUse []*config.NValue) int {
 	for i := range revUse {
-		if len(revUse[i].Prefix) == 0 && len(revUse[i].Suffix) == 0 {
-			continue
-		}
 		if len(revUse[i].Prefix) > 0 && !strings.HasPrefix(query, revUse[i].Prefix) {
 			continue
 		}
 		if len(revUse[i].Suffix) > 0 && !strings.HasSuffix(query, revUse[i].Suffix) {
+			continue
+		}
+		if revUse[i].Regex != nil && revUse[i].Regex.FindStringIndex(query) == nil {
 			continue
 		}
 		return revUse[i].Value
@@ -78,7 +78,7 @@ func reverseSuffixDepth(query string, defaultReverseDepth int, revUse []config.N
 	return defaultReverseDepth
 }
 
-func useReverseDepth(query string, reverseDepth int, revUse []config.NValue) bool {
+func useReverseDepth(query string, reverseDepth int, revUse []*config.NValue) bool {
 	if reverseDepth == -1 {
 		return false
 	}

--- a/finder/index_test.go
+++ b/finder/index_test.go
@@ -1,0 +1,28 @@
+package finder
+
+import (
+	"testing"
+
+	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_useReverse(t *testing.T) {
+	assert := assert.New(t)
+
+	table := []struct {
+		query  string
+		result bool
+	}{
+		{"a.b.c.d.e", false},
+		{"a.b*", false},
+		{"a.b.c.d.e*", false},
+		{"a.b.c.d*.e", true},
+		{"a.b*.c*.d.e", true},
+		{"a.b*.c*.d*.e", true},
+	}
+
+	for _, tt := range table {
+		assert.Equal(tt.result, useReverseDepth(tt.query, 1, []config.NValue{}), tt.query)
+	}
+}

--- a/finder/index_test.go
+++ b/finder/index_test.go
@@ -24,7 +24,7 @@ func Test_useReverse(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		assert.Equal(tt.result, useReverseDepth(tt.query, 1, []config.NValue{}), tt.query)
+		assert.Equal(tt.result, useReverseDepth(tt.query, 1, []*config.NValue{}), tt.query)
 	}
 }
 
@@ -49,17 +49,18 @@ func Test_useReverseWithFixedDepth(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		assert.Equal(tt.result, useReverseDepth(tt.query, tt.depth, []config.NValue{}), fmt.Sprintf("%s with depth %d", tt.query, tt.depth))
+		assert.Equal(tt.result, useReverseDepth(tt.query, tt.depth, []*config.NValue{}), fmt.Sprintf("%s with depth %d", tt.query, tt.depth))
 	}
 }
 
 func Test_useReverseDepth(t *testing.T) {
 	assert := assert.New(t)
 
-	usesDepth := []config.NValue{
-		{Suffix: ".sum", Value: 2},
-		{Prefix: "test.", Suffix: ".alloc", Value: 2},
-		{Prefix: "test2.", Value: 2},
+	usesDepth := []*config.NValue{
+		&config.NValue{Suffix: ".sum", Value: 2},
+		&config.NValue{Prefix: "test.", Suffix: ".alloc", Value: 2},
+		&config.NValue{Prefix: "test2.", Value: 2},
+		&config.NValue{RegexStr: `^a\..*\.max$`, Value: 2},
 	}
 
 	table := []struct {
@@ -73,9 +74,43 @@ func Test_useReverseDepth(t *testing.T) {
 		{"test.b.c*.d.alloc", 1, true},
 		{"test2.b.c*.d*.e", 1, false},
 		{"test2.b.c*.d.e", 1, true},
+		{"a.b.c.d*.max", 1, false}, // regex test
+		{"a.b.c*.d.max", 1, true},  // regex test
 	}
+
+	assert.NoError(config.IndexUseReversesValidate(usesDepth))
 
 	for _, tt := range table {
 		assert.Equal(tt.result, useReverseDepth(tt.query, tt.depth, usesDepth), fmt.Sprintf("%s with depth %d", tt.query, tt.depth))
+	}
+}
+
+func Benchmark_useReverseDepth(b *testing.B) {
+	usesDepth := []*config.NValue{
+		&config.NValue{Prefix: "test2.", Value: 2},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = useReverseDepth("test2.b.c*.d.e", 1, usesDepth)
+	}
+}
+
+func Benchmark_useReverseDepthPrefixSuffix(b *testing.B) {
+	usesDepth := []*config.NValue{
+		&config.NValue{Prefix: "test2.", Suffix: ".e", Value: 2},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = useReverseDepth("test2.b.c*.d.e", 1, usesDepth)
+	}
+}
+
+func Benchmark_useReverseDepthRegex(b *testing.B) {
+	usesDepth := []*config.NValue{
+		&config.NValue{RegexStr: `^a\..*\.max$`, Value: 2},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = useReverseDepth("a.b.c*.d.max", 1, usesDepth)
 	}
 }

--- a/finder/index_test.go
+++ b/finder/index_test.go
@@ -1,6 +1,7 @@
 package finder
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lomik/graphite-clickhouse/config"
@@ -24,5 +25,57 @@ func Test_useReverse(t *testing.T) {
 
 	for _, tt := range table {
 		assert.Equal(tt.result, useReverseDepth(tt.query, 1, []config.NValue{}), tt.query)
+	}
+}
+
+func Test_useReverseWithFixedDepth(t *testing.T) {
+	assert := assert.New(t)
+
+	table := []struct {
+		query  string
+		depth  int
+		result bool
+	}{
+		{"a.b.c.d.e", 0, false},
+		{"a.b.c.d.e", 1, false},
+		{"a.b.c.d.e*", 1, false},
+		{"a.b.c.d*.e", 1, true},
+		{"a.b.c.d*.e", 2, false},
+		{"a*.b.c.d*.e", 2, true}, // Wildcard at first level, use reverse if possible
+		{"a.b*.c.d*.e", 2, false},
+		{"a.*.c.*.e.*.j", 2, false},
+		{"a.*.c.*.e.*.j", 1, true},
+		{"a.b*.c.*d.e", 2, false},
+	}
+
+	for _, tt := range table {
+		assert.Equal(tt.result, useReverseDepth(tt.query, tt.depth, []config.NValue{}), fmt.Sprintf("%s with depth %d", tt.query, tt.depth))
+	}
+}
+
+func Test_useReverseDepth(t *testing.T) {
+	assert := assert.New(t)
+
+	usesDepth := []config.NValue{
+		{Suffix: ".sum", Value: 2},
+		{Prefix: "test.", Suffix: ".alloc", Value: 2},
+		{Prefix: "test2.", Value: 2},
+	}
+
+	table := []struct {
+		query  string
+		depth  int
+		result bool
+	}{
+		{"a.b.c.d*.sum", 1, false},
+		{"a.b.c*.d.sum", 1, true},
+		{"test.b.c*.d*.alloc", 1, false},
+		{"test.b.c*.d.alloc", 1, true},
+		{"test2.b.c*.d*.e", 1, false},
+		{"test2.b.c*.d.e", 1, true},
+	}
+
+	for _, tt := range table {
+		assert.Equal(tt.result, useReverseDepth(tt.query, tt.depth, usesDepth), fmt.Sprintf("%s with depth %d", tt.query, tt.depth))
 	}
 }

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -77,9 +77,8 @@ func clearGlob(query string) string {
 			builder.WriteString(query[p:])
 		}
 		return builder.String()
-	} else {
-		return query
 	}
+	return query
 }
 
 func glob(field string, query string, optionalDotAtEnd bool) string {

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -5,10 +5,89 @@ import (
 	"strings"
 )
 
+// clearGlob cleanup grafana globs like {name}
+func clearGlob(query string) string {
+	p := 0
+	s := strings.IndexAny(query, "{[")
+	if s == -1 {
+		return query
+	}
+
+	found := false
+	var builder strings.Builder
+
+	for {
+		var e int
+		if query[s] == '{' {
+			e = strings.IndexAny(query[s:], "}.")
+			if e == -1 || query[s+e] == '.' {
+				// { not closed, glob with error
+				break
+			}
+			e += s + 1
+			delim := strings.IndexRune(query[s+1:e], ',')
+			if delim == -1 {
+				if !found {
+					builder.Grow(len(query) - 2)
+					found = true
+				}
+				builder.WriteString(query[p:s])
+				builder.WriteString(query[s+1 : e-1])
+				p = e
+			}
+		} else {
+			e = strings.IndexAny(query[s+1:], "].")
+			if e == -1 || query[s+e] == '.' {
+				// [ not closed, glob with error
+				break
+			} else {
+				symbols := 0
+				for _, c := range query[s+1 : s+e+1] {
+					_ = c // for loop over runes
+					symbols++
+					if symbols == 2 {
+						break
+					}
+				}
+				if symbols <= 1 {
+					if !found {
+						builder.Grow(len(query) - 2)
+						found = true
+					}
+					builder.WriteString(query[p:s])
+					builder.WriteString(query[s+1 : s+e+1])
+					p = e + s + 2
+				}
+			}
+			e += s + 2
+		}
+
+		if e >= len(query) {
+			break
+		}
+		s = strings.IndexAny(query[e:], "{[")
+		if s == -1 {
+			break
+		}
+		s += e
+	}
+
+	if found {
+		if p < len(query) {
+			builder.WriteString(query[p:])
+		}
+		return builder.String()
+	} else {
+		return query
+	}
+}
+
 func glob(field string, query string, optionalDotAtEnd bool) string {
 	if query == "*" {
 		return ""
 	}
+
+	query = clearGlob(query)
 
 	if !HasWildcard(query) {
 		if optionalDotAtEnd {

--- a/pkg/where/match_test.go
+++ b/pkg/where/match_test.go
@@ -11,7 +11,7 @@ func TestGlob(t *testing.T) {
 		{"a.{a,b}.te{s}t.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]test[.]b$')"},
 		{"a.{a,b}.te{s,t}*.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]te(s|t)([^.]*?)[.]b$')"},
 		{"a.{a,b}.test*.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]test([^.]*?)[.]b$')"},
-		{"a.[b].te{s}t.b", "test LIKE 'a.%' AND match(test, '^a[.][b][.]test[.]b$')"},
+		{"a.[b].te{s}t.b", "test='a.b.test.b'"},
 		{"a.[ab].te{s,t}*.b", "test LIKE 'a.%' AND match(test, '^a[.][ab][.]te(s|t)([^.]*?)[.]b$')"},
 	}
 	for _, tt := range tests {

--- a/pkg/where/match_test.go
+++ b/pkg/where/match_test.go
@@ -1,0 +1,24 @@
+package where
+
+import "testing"
+
+func TestGlob(t *testing.T) {
+	field := "test"
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"a.{a,b}.te{s}t.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]test[.]b$')"},
+		{"a.{a,b}.te{s,t}*.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]te(s|t)([^.]*?)[.]b$')"},
+		{"a.{a,b}.test*.b", "test LIKE 'a.%' AND match(test, '^a[.](a|b)[.]test([^.]*?)[.]b$')"},
+		{"a.[b].te{s}t.b", "test LIKE 'a.%' AND match(test, '^a[.][b][.]test[.]b$')"},
+		{"a.[ab].te{s,t}*.b", "test LIKE 'a.%' AND match(test, '^a[.][ab][.]te(s|t)([^.]*?)[.]b$')"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			if got := Glob(field, tt.query); got != tt.want {
+				t.Errorf("Glob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/where/match_test.go
+++ b/pkg/where/match_test.go
@@ -2,6 +2,32 @@ package where
 
 import "testing"
 
+func Test_clearGlob(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"a.{a,b}.te{s}t.b", "a.{a,b}.test.b"},
+		{"a.{a,b}.te{s,t}*.b", "a.{a,b}.te{s,t}*.b"},
+		{"a.{a,b}.test*.b", "a.{a,b}.test*.b"},
+		{"a.[b].te{s}t.b", "a.b.test.b"},
+		{"a.[ab].te{s,t}*.b", "a.[ab].te{s,t}*.b"},
+		{"a.{a,b.}.te{s,t}*.b", "a.{a,b.}.te{s,t}*.b"}, // some broken
+		{"О.[б].те{s}t.b", "О.б.теst.b"},               // utf-8 string
+		{"О.[].те{}t.b", "О..теt.b"},                   // utf-8 string with empthy blocks
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			if got := clearGlob(tt.query); got != tt.want {
+				t.Errorf("clearGlob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGlob(t *testing.T) {
 	field := "test"
 	tests := []struct {

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -28,6 +28,14 @@ func HasWildcard(target string) bool {
 	return strings.IndexAny(target, "[]{}*?") > -1
 }
 
+func IndexReverseWildcard(target string) int {
+	return strings.LastIndexAny(target, "[]{}*?")
+}
+
+func IndexWildcardOrDot(target string) int {
+	return strings.IndexAny(target, ".[]{}*?")
+}
+
 func NonRegexpPrefix(expr string) string {
 	s := regexp.QuoteMeta(expr)
 	for i := 0; i < len(expr); i++ {


### PR DESCRIPTION
Allow tune of usage reverse/forward index.

For example, reverse query of `a.b.c.*.e` might be slow in some cases. With this we can force use forward index for this queries.
