### PR TITLE
return Forbidden status if metrics per target limit reached

### DIFF
--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -69,7 +69,8 @@ func HandleError(w http.ResponseWriter, err error) {
 	}
 	errCode, ok := err.(*ErrorWithCode)
 	if ok {
-		if errCode.Code > 500 && errCode.Code < 512 {
+		if (errCode.Code > 500 && errCode.Code < 512) ||
+			errCode.Code == http.StatusBadRequest || errCode.Code == http.StatusForbidden {
 			http.Error(w, html.EscapeString(errCode.Error()), errCode.Code)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/render/query.go
+++ b/render/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -62,7 +63,7 @@ func (m *MultiFetchRequest) checkMetricsLimitExceeded(num int) error {
 	}
 	for _, t := range *m {
 		if num < t.AM.Len() {
-			return fmt.Errorf("metrics limit exceeded: %v < %v", num, t.AM.Len())
+			return clickhouse.NewErrorWithCode(fmt.Sprintf("metrics limit exceeded: %d < %d", num, t.AM.Len()), http.StatusForbidden)
 		}
 	}
 	return nil


### PR DESCRIPTION
Return Forbidden status for render if metrics per target limit (max-metrics-per-target) reached.