### PR TITLE
Tagged targets and errors with multi value globs and regex

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -78,7 +78,10 @@ func (h *Handler) requestExpr(r *http.Request) (*where.Where, *where.Where, map[
 		return wr, pw, usedTags, err
 	}
 
-	wr, pw = finder.TaggedWhere(terms)
+	wr, pw, err = finder.TaggedWhere(terms)
+	if err != nil {
+		return wr, pw, usedTags, err
+	}
 
 	for i := 0; i < len(expr); i++ {
 		a := strings.Split(expr[i], "=")

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -69,7 +69,7 @@ func NewTagged(url string, table string, absKeepEncoded bool, opts clickhouse.Op
 }
 
 func (term *TaggedTerm) concat() string {
-	return where.ConcatKV(term.Key, term.Value)
+	return term.Key + "=" + term.Value
 }
 
 func (term *TaggedTerm) concatMask() string {

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -69,7 +69,7 @@ func NewTagged(url string, table string, absKeepEncoded bool, opts clickhouse.Op
 }
 
 func (term *TaggedTerm) concat() string {
-	return fmt.Sprintf("%s=%s", term.Key, term.Value)
+	return where.ConcatKV(term.Key, term.Value)
 }
 
 func (term *TaggedTerm) concatMask() string {
@@ -117,9 +117,10 @@ func TaggedTermWhere1(term *TaggedTerm) (string, error) {
 			return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat())), nil
 		}
 	case TaggedTermMatch:
-		return where.Match("Tag1", term.concat()), nil
+		return where.Match("Tag1", term.Key, term.Value), nil
 	case TaggedTermNotMatch:
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
+		// return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", term.Key, term.Value), nil
+		return "NOT " + where.Match("Tag1", term.Key, term.Value), nil
 	default:
 		return "", nil
 	}
@@ -164,9 +165,9 @@ func TaggedTermWhereN(term *TaggedTerm) (string, error) {
 			return "NOT arrayExists((x) -> " + where.Eq("x", term.concat()) + ", Tags)", nil
 		}
 	case TaggedTermMatch:
-		return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
+		return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Match("x", term.Key, term.Value)), nil
 	case TaggedTermNotMatch:
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
+		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.Key, term.Value)), nil
 	default:
 		return "", nil
 	}

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -72,46 +72,89 @@ func (term *TaggedTerm) concat() string {
 	return fmt.Sprintf("%s=%s", term.Key, term.Value)
 }
 
-func TaggedTermWhere1(term *TaggedTerm) string {
+func TaggedTermWhere1(term *TaggedTerm) (string, error) {
 	// positive expression check only in Tag1
 	// negative check in all Tags
 	switch term.Op {
 	case TaggedTermEq:
-		return where.Eq("Tag1", term.concat())
+		var values []string
+		if err := where.GlobExpandSimple(term.Value, term.Key+"=", &values); err != nil {
+			return "", err
+		}
+		if len(values) == 1 {
+			return where.Eq("Tag1", values[0]), nil
+		} else if len(values) > 1 {
+			return where.In("Tag1", values), nil
+		} else {
+			return where.Eq("Tag1", term.concat()), nil
+		}
 	case TaggedTermNe:
 		if term.Value == "" {
 			// special case
 			// container_name!=""  ==> container_name exists and it is not empty
-			return where.HasPrefixAndNotEq("Tag1", term.Key+"=")
+			return where.HasPrefixAndNotEq("Tag1", term.Key+"="), nil
 		}
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat()))
+		var values []string
+		if err := where.GlobExpandSimple(term.Value, term.Key+"=", &values); err != nil {
+			return "", err
+		}
+		if len(values) == 1 {
+			return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", values[0])), nil
+		} else if len(values) > 1 {
+			return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.In("x", values)), nil
+		} else {
+			return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat())), nil
+		}
 	case TaggedTermMatch:
-		return where.Match("Tag1", term.concat())
+		return where.Match("Tag1", term.concat()), nil
 	case TaggedTermNotMatch:
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat()))
+		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
 	default:
-		return ""
+		return "", nil
 	}
 }
 
-func TaggedTermWhereN(term *TaggedTerm) string {
+func TaggedTermWhereN(term *TaggedTerm) (string, error) {
 	// arrayExists((x) -> %s, Tags)
 	switch term.Op {
 	case TaggedTermEq:
-		return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat()))
+		//return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat()))
+		var values []string
+		if err := where.GlobExpandSimple(term.Value, term.Key+"=", &values); err != nil {
+			return "", err
+		}
+		if len(values) == 1 {
+			return "arrayExists((x) -> " + where.Eq("x", values[0]) + ", Tags)", nil
+		} else if len(values) > 1 {
+			return "arrayExists((x) -> " + where.In("x", values) + ", Tags)", nil
+		} else {
+			return "arrayExists((x) -> " + where.Eq("x", term.concat()) + ", Tags)", nil
+		}
 	case TaggedTermNe:
 		if term.Value == "" {
 			// special case
 			// container_name!=""  ==> container_name exists and it is not empty
-			return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.HasPrefixAndNotEq("x", term.Key+"="))
+			return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.HasPrefixAndNotEq("x", term.Key+"=")), nil
 		}
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat()))
+		var values []string
+		if err := where.GlobExpandSimple(term.Value, term.Key+"=", &values); err != nil {
+			return "", err
+		}
+		if len(values) == 1 {
+			return "NOT arrayExists((x) -> " + where.Eq("x", values[0]) + ", Tags)", nil
+		} else if len(values) > 1 {
+			return "NOT arrayExists((x) -> " + where.In("x", values) + ", Tags)", nil
+		} else {
+			return "NOT arrayExists((x) -> " + where.Eq("x", term.concat()) + ", Tags)", nil
+		}
+
+		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Eq("x", term.concat())), nil
 	case TaggedTermMatch:
-		return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Match("x", term.concat()))
+		return fmt.Sprintf("arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
 	case TaggedTermNotMatch:
-		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat()))
+		return fmt.Sprintf("NOT arrayExists((x) -> %s, Tags)", where.Match("x", term.concat())), nil
 	default:
-		return ""
+		return "", nil
 	}
 }
 
@@ -206,20 +249,27 @@ func ParseSeriesByTag(query string) ([]TaggedTerm, error) {
 	return ParseTaggedConditions(conditions)
 }
 
-func TaggedWhere(terms []TaggedTerm) (*where.Where, *where.Where) {
+func TaggedWhere(terms []TaggedTerm) (*where.Where, *where.Where, error) {
 	w := where.New()
 	pw := where.New()
-	x := TaggedTermWhere1(&terms[0])
+	x, err := TaggedTermWhere1(&terms[0])
+	if err != nil {
+		return nil, nil, err
+	}
 	if terms[0].Op == TaggedTermMatch {
 		pw.And(x)
 	}
 	w.And(x)
 
 	for i := 1; i < len(terms); i++ {
-		w.And(TaggedTermWhereN(&terms[i]))
+		and, err := TaggedTermWhereN(&terms[i])
+		if err != nil {
+			return nil, nil, err
+		}
+		w.And(and)
 	}
 
-	return w, pw
+	return w, pw, nil
 }
 
 func (t *TaggedFinder) Execute(ctx context.Context, query string, from int64, until int64) error {
@@ -232,8 +282,10 @@ func (t *TaggedFinder) Execute(ctx context.Context, query string, from int64, un
 }
 
 func (t *TaggedFinder) ExecutePrepared(ctx context.Context, terms []TaggedTerm, from int64, until int64) error {
-	var err error
-	w, pw := TaggedWhere(terms)
+	w, pw, err := TaggedWhere(terms)
+	if err != nil {
+		return err
+	}
 
 	w.Andf(
 		"Date >='%s' AND Date <= '%s'",

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -20,6 +20,7 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
 		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
 		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", false},
+		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
 		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
 		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, '^key=hello.world$'), Tags))", "", false},
 		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, '^host=Vladimirs-MacBook-Pro\\.local$'), Tags))`, "", false},

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -17,14 +17,14 @@ func TestTaggedWhere(t *testing.T) {
 		isErr    bool
 	}{
 		// info about _tag "directory"
-		// {"seriesByTag('key=value')", "Tag1='key=value'", "", false},
-		// {"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
-		// {"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
-		// {"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
-		// {"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
-		// {"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
-		// {"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
-		// {"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*value'), Tags))", "", false},
+		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
+		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
+		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
+		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
+		{"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
+		{"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
+		{"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
+		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*value'), Tags))", "", false},
 		{"seriesByTag('name=rps', 'key=~^value$')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
 		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*hello.world'), Tags))", "", false},
 		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=%' AND match(x, '^host=.*Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -19,10 +19,10 @@ func TestTaggedWhere(t *testing.T) {
 		// info about _tag "directory"
 		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
 		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
-		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '__name__=cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '__name__=cpu.usage')", false},
+		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", false},
 		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
-		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, 'key=hello.world'), Tags))", "", false},
-		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, 'host=Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
+		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, '^key=hello.world$'), Tags))", "", false},
+		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, '^host=Vladimirs-MacBook-Pro\\.local$'), Tags))`, "", false},
 		// grafana multi-value variable produce this
 		{"seriesByTag('name=value','what=*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false},        // If All masked to value with *
 		{"seriesByTag('name=value','what=*x')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false},      // If All masked to value with *

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -32,6 +32,7 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=value','what=*x')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false},      // If All masked to value with *
 		{"seriesByTag('name=value','what!=*x')", "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false}, // If All masked to value with *
 		{"seriesByTag('name={avg,max}')", "Tag1 IN ('__name__=avg','__name__=max')", "", false},
+		{"seriesByTag('name=m{in}')", "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", "Tag1='__name__=m{in,ax'", "", true},
 		{"seriesByTag('name=value','what={avg,max}')", "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -17,15 +17,15 @@ func TestTaggedWhere(t *testing.T) {
 		isErr    bool
 	}{
 		// info about _tag "directory"
-		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
-		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
-		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
-		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
-		{"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
-		{"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
-		{"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
-		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*value'), Tags))", "", false},
-		{"seriesByTag('name=rps', 'key=~^value$')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=value' AND match(x, '^key=.*value$'), Tags))", "", false},
+		// {"seriesByTag('key=value')", "Tag1='key=value'", "", false},
+		// {"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
+		// {"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
+		// {"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
+		// {"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
+		// {"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
+		// {"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
+		// {"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*value'), Tags))", "", false},
+		{"seriesByTag('name=rps', 'key=~^value$')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
 		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*hello.world'), Tags))", "", false},
 		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=%' AND match(x, '^host=.*Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
 		// grafana multi-value variable produce this

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -19,11 +19,14 @@ func TestTaggedWhere(t *testing.T) {
 		// info about _tag "directory"
 		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
 		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
-		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=cpu.usage$')", false},
-		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
+		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
+		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
+		{"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
+		{"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
+		{"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
 		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
-		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, '^key=hello.world$'), Tags))", "", false},
-		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, '^host=Vladimirs-MacBook-Pro\\.local$'), Tags))`, "", false},
+		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, '^key=.*hello.world'), Tags))", "", false},
+		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, '^host=.*Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
 		// grafana multi-value variable produce this
 		{"seriesByTag('name=value','what=*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false},        // If All masked to value with *
 		{"seriesByTag('name=value','what=*x')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false},      // If All masked to value with *

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -24,6 +24,9 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, 'key=hello.world'), Tags))", "", false},
 		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, 'host=Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
 		// grafana multi-value variable produce this
+		{"seriesByTag('name=value','what=*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false},        // If All masked to value with *
+		{"seriesByTag('name=value','what=*x')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false},      // If All masked to value with *
+		{"seriesByTag('name=value','what!=*x')", "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false}, // If All masked to value with *
 		{"seriesByTag('name={avg,max}')", "Tag1 IN ('__name__=avg','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax}')", "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", "Tag1='__name__=m{in,ax'", "", true},

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -19,14 +19,15 @@ func TestTaggedWhere(t *testing.T) {
 		// info about _tag "directory"
 		{"seriesByTag('key=value')", "Tag1='key=value'", "", false},
 		{"seriesByTag('name=rps')", "Tag1='__name__=rps'", "", false},
-		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=cpu%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
+		{"seriesByTag('name=~cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu.usage')", false},
 		{"seriesByTag('name=~cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem')", false},
 		{"seriesByTag('name=~cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=.*cpu|mem$')", false},
 		{"seriesByTag('name=~^cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem')", false},
 		{"seriesByTag('name=~^cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", "Tag1 LIKE '\\\\_\\\\_name\\\\_\\\\_=%' AND match(Tag1, '^__name__=cpu|mem$')", false},
-		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x='key=value', Tags))", "", false},
-		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=hello%' AND match(x, '^key=.*hello.world'), Tags))", "", false},
-		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=Vladimirs-MacBook-Pro%' AND match(x, '^host=.*Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
+		{"seriesByTag('name=rps', 'key=~value')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*value'), Tags))", "", false},
+		{"seriesByTag('name=rps', 'key=~^value$')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=value' AND match(x, '^key=.*value$'), Tags))", "", false},
+		{"seriesByTag('name=rps', 'key=~hello.world')", "(Tag1='__name__=rps') AND (arrayExists((x) -> x LIKE 'key=%' AND match(x, '^key=.*hello.world'), Tags))", "", false},
+		{`seriesByTag('cpu=cpu-total','host=~Vladimirs-MacBook-Pro\.local')`, `(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'host=%' AND match(x, '^host=.*Vladimirs-MacBook-Pro\\.local'), Tags))`, "", false},
 		// grafana multi-value variable produce this
 		{"seriesByTag('name=value','what=*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false},        // If All masked to value with *
 		{"seriesByTag('name=value','what=*x')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%x', Tags))", "", false},      // If All masked to value with *

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -64,15 +64,24 @@ func TreeGlob(field string, query string) string {
 	return glob(field, query, true)
 }
 
-func ConcatKV(key, value string) string {
-	return key + opEq + value
+func ConcatMatchKV(key, value string) string {
+	startLine := value[0] == '^'
+	endLine := value[len(value)-1] == '$'
+	if startLine {
+		return key + opEq + value[1:]
+	} else if endLine {
+		return key + opEq + value + "\\\\%"
+	}
+	return key + opEq + "\\\\%" + value
 }
 
 func Match(field string, key, value string) string {
-	expr := ConcatKV(key, value)
+	expr := ConcatMatchKV(key, value)
 	simplePrefix := NonRegexpPrefix(expr)
 	if len(simplePrefix) == len(expr) {
 		return Eq(field, expr)
+	} else if len(simplePrefix) == len(expr)-1 && expr[len(expr)-1] == '$' {
+		return Eq(field, simplePrefix)
 	}
 
 	if simplePrefix == "" {

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -66,8 +66,8 @@ func Match(field string, expr string) string {
 	}
 
 	if simplePrefix == "" {
-		return fmt.Sprintf("match(%s, %s)", field, quote(expr))
+		return fmt.Sprintf("match(%s, %s)", field, quoteRegex(expr))
 	}
 
-	return fmt.Sprintf("%s AND match(%s, %s)", HasPrefix(field, simplePrefix), field, quote(expr))
+	return fmt.Sprintf("%s AND match(%s, %s)", HasPrefix(field, simplePrefix), field, quoteRegex(expr))
 }

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+var (
+	opEq    string = "="
+	opMatch string = "=~"
+)
+
 func glob(field string, query string, optionalDotAtEnd bool) string {
 	if query == "*" {
 		return ""
@@ -59,15 +64,23 @@ func TreeGlob(field string, query string) string {
 	return glob(field, query, true)
 }
 
-func Match(field string, expr string) string {
+func ConcatKV(key, value string) string {
+	return key + opEq + value
+}
+
+func Match(field string, key, value string) string {
+	expr := ConcatKV(key, value)
 	simplePrefix := NonRegexpPrefix(expr)
 	if len(simplePrefix) == len(expr) {
 		return Eq(field, expr)
 	}
 
 	if simplePrefix == "" {
-		return fmt.Sprintf("match(%s, %s)", field, quoteRegex(expr))
+		return fmt.Sprintf("match(%s, %s)", field, quoteRegex(key, value))
 	}
 
-	return fmt.Sprintf("%s AND match(%s, %s)", HasPrefix(field, simplePrefix), field, quoteRegex(expr))
+	return fmt.Sprintf("%s AND match(%s, %s)",
+		HasPrefix(field, simplePrefix),
+		field, quoteRegex(key, value),
+	)
 }

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -73,6 +73,12 @@ func NonRegexpPrefix(expr string) string {
 	s := regexp.QuoteMeta(expr)
 	for i := 0; i < len(expr); i++ {
 		if expr[i] != s[i] || expr[i] == '\\' {
+			if len(expr) > i+1 && expr[i] == '|' {
+				eq := strings.LastIndexAny(expr[:i], "=~")
+				if eq > 0 {
+					return expr[:eq+1]
+				}
+			}
 			return expr[:i]
 		}
 	}

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -108,6 +108,10 @@ func quote(value interface{}) string {
 	}
 }
 
+func quoteRegex(value string) string {
+	return fmt.Sprintf("'^%s$'", escape(value))
+}
+
 func Like(field, s string) string {
 	return fmt.Sprintf("%s LIKE '%s'", field, s)
 }

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -114,11 +114,6 @@ func quote(value interface{}) string {
 	}
 }
 
-// {'name=~cpu.usage', '^__name__=.*cpu.usage'},
-// {'name=~cpu|mem',   '^__name__=.*cpu|mem'},
-// {'name=~cpu|mem$',  '^__name__=.*cpu|mem$'},
-// {'name=~^cpu|mem',  '^__name__=^cpu|mem$'},
-// {'name=~^cpu|mem$', '^__name__=cpu|mem$'},
 func quoteRegex(key, value string) string {
 	startLine := value[0] == '^'
 	endLine := value[len(value)-1] == '$'

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -108,6 +108,10 @@ func quote(value interface{}) string {
 	}
 }
 
+func Like(field, s string) string {
+	return fmt.Sprintf("%s LIKE '%s'", field, s)
+}
+
 func Eq(field, value interface{}) string {
 	return fmt.Sprintf("%s=%s", field, quote(value))
 }

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -58,6 +58,8 @@ func TestNonRegexpPrefix(t *testing.T) {
 	}{
 		{`test[.]([^.]*?)[.]foo`, `test`},
 		{`__name__=cpu.load`, `__name__=cpu`},
+		{`__name__=~(cpu|mem)`, `__name__=~`},
+		{`__name__=~cpu|mem`, `__name__=~`},
 	}
 
 	for _, test := range table {

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -25,9 +25,10 @@ func TestGlobExpandSimple(t *testing.T) {
 		t.Run(tt.value, func(t *testing.T) {
 			var got []string
 			err := GlobExpandSimple(tt.value, "", &got)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Expand() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				assert.Error(t, err, "Expand() not returns error for %v", tt.value)
+			} else {
+				assert.NoErrorf(t, err, "Expand() returns error %v for %v", err, tt.value)
 			}
 			assert.Equal(t, tt.want, got, "Expand() result")
 		})

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -18,6 +18,7 @@ func TestGlobExpandSimple(t *testing.T) {
 		{"{a,bc,d}E", []string{"aE", "bcE", "dE"}, false},
 		{"S{a,bc,d}E", []string{"SaE", "SbcE", "SdE"}, false},
 		{"S{a,bc,d}E{f,h}", []string{"SaEf", "SaEh", "SbcEf", "SbcEh", "SdEf", "SdEh"}, false},
+		{"test{a,b}", []string{"testa", "testb"}, false},
 		{"S{a,bc,d}}E{f,h}", nil, true}, //error
 		{"S{{a,bc,d}E{f,h}", nil, true}, //error
 	}

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -7,6 +7,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGlobExpandSimple(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    []string
+		wantErr bool
+	}{
+		{"{a,bc,d}", []string{"a", "bc", "d"}, false},
+		{"S{a,bc,d}", []string{"Sa", "Sbc", "Sd"}, false},
+		{"{a,bc,d}E", []string{"aE", "bcE", "dE"}, false},
+		{"S{a,bc,d}E", []string{"SaE", "SbcE", "SdE"}, false},
+		{"S{a,bc,d}E{f,h}", []string{"SaEf", "SaEh", "SbcEf", "SbcEh", "SdEf", "SdEh"}, false},
+		{"S{a,bc,d}}E{f,h}", nil, true}, //error
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			var got []string
+			err := GlobExpandSimple(tt.value, "", &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Expand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got, "Expand() result")
+		})
+	}
+}
+
 func TestGlobToRegexp(t *testing.T) {
 	table := []struct {
 		glob   string

--- a/pkg/where/where_test.go
+++ b/pkg/where/where_test.go
@@ -19,6 +19,7 @@ func TestGlobExpandSimple(t *testing.T) {
 		{"S{a,bc,d}E", []string{"SaE", "SbcE", "SdE"}, false},
 		{"S{a,bc,d}E{f,h}", []string{"SaEf", "SaEh", "SbcEf", "SbcEh", "SdEf", "SdEh"}, false},
 		{"S{a,bc,d}}E{f,h}", nil, true}, //error
+		{"S{{a,bc,d}E{f,h}", nil, true}, //error
 	}
 	for _, tt := range tests {
 		t.Run(tt.value, func(t *testing.T) {


### PR DESCRIPTION
1) For example, query like
`seriesByTag(.., 'instance=${Instance}', ..)`

If selected instances 1 and 10 (grafana with multi-value variable), grafana expand this to

`seriesByTag(.., 'instance={1,10}',  ..)`

graphite-clickhouse produce wrong query like
`SELECT Path FROM graphite_tags2  WHERE ((((((.. AND (arrayExists((x) -> x='instance={1,10}', Tags))) ..`

2) In some cases we use asterisk for mask All value. It's work fine for plain metrics. but not work with tagged.

3) Also match pattern not have `^` at the begging and `$` at the end. So we have more than expected metrics in results.

4) Also fix for https://github.com/lomik/graphite-clickhouse/issues/80
