### PR TITLE
Tagged multi value globs

### DIFF
--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -38,6 +38,8 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=m{in,ax')", "Tag1='__name__=m{in,ax'", "", true},
 		{"seriesByTag('name=value','what={avg,max}')", "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		// grafana workaround for multi-value variables default, masked with *
+		{"seriesByTag('name=value','what=~*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
 	}
 
 	for _, test := range table {

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	opEq    string = "="
+	opEq string = "="
 )
 
 // clearGlob cleanup grafana globs like {name}
@@ -153,6 +153,9 @@ func ConcatMatchKV(key, value string) string {
 }
 
 func Match(field string, key, value string) string {
+	if value == "*" {
+		return Like(field, key+"=%")
+	}
 	expr := ConcatMatchKV(key, value)
 	simplePrefix := NonRegexpPrefix(expr)
 	if len(simplePrefix) == len(expr) {


### PR DESCRIPTION
At https://github.com/lomik/graphite-clickhouse/pull/141 I not handle  tag filed value`*` (used for All in grafana).
For regular expression it's not a right choose. `*` is not a valid regular expression, but for compatibility can be interpreted as any value.