### PR TITLE
Additional errors checking

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -151,7 +151,7 @@ func (h *Handler) ServeTags(w http.ResponseWriter, r *http.Request) {
 		nil,
 	)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		clickhouse.HandleError(w, err)
 		return
 	}
 
@@ -268,7 +268,7 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.Marshal(rows)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		clickhouse.HandleError(w, err)
 		return
 	}
 

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -53,6 +53,10 @@ var ErrUvarintOverflow = errors.New("ReadUvarint: varint overflows a 64-bit inte
 var ErrClickHouseResponse = errors.New("Malformed response from clickhouse")
 
 func HandleError(w http.ResponseWriter, err error) {
+	if errors.Is(err, context.Canceled) {
+		http.Error(w, "Storage read context canceled", http.StatusGatewayTimeout)
+		return
+	}
 	netErr, ok := err.(net.Error)
 	if ok {
 		if netErr.Timeout() {


### PR DESCRIPTION
Some changes for reduce InternalServerError errors
1. Return GatewayTimeout on context canceled (instead of InternalServerError)
2. Check error in tags autocompelete handler (like find)
