### PR TITLE
Fix for empty tag value during autocompletion

### DIFF
--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -38,6 +38,8 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=m{in,ax')", "Tag1='__name__=m{in,ax'", "", true},
 		{"seriesByTag('name=value','what={avg,max}')", "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		// grafana workaround for multi-value variables default, masked with *
+		{"seriesByTag('name=value','what=~*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
 	}
 
 	for _, test := range table {

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -40,6 +40,8 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=value','what!={avg,max}')", "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
 		{"seriesByTag('name=value','what=~*')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
+		// empty tag value during autocompletion
+		{"seriesByTag('name=value','what=~')", "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
 	}
 
 	for _, test := range table {

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -153,7 +153,7 @@ func ConcatMatchKV(key, value string) string {
 }
 
 func Match(field string, key, value string) string {
-	if value == "*" {
+	if len(value) == 0 || value == "*" {
 		return Like(field, key+"=%")
 	}
 	expr := ConcatMatchKV(key, value)

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	opEq    string = "="
+	opEq string = "="
 )
 
 // clearGlob cleanup grafana globs like {name}
@@ -153,6 +153,9 @@ func ConcatMatchKV(key, value string) string {
 }
 
 func Match(field string, key, value string) string {
+	if value == "*" {
+		return Like(field, key+"=%")
+	}
 	expr := ConcatMatchKV(key, value)
 	simplePrefix := NonRegexpPrefix(expr)
 	if len(simplePrefix) == len(expr) {


### PR DESCRIPTION
Empty tag value during autocompletion produce a panic
```
panic: runtime error: index out of range [0] with length 0
goroutine 2209417 [running]:
github.com/lomik/graphite-clickhouse/pkg/where.ConcatMatchKV(...)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/pkg/where/match.go:145
github.com/lomik/graphite-clickhouse/pkg/where.Match(0x1bedf96, 0x1, 0xc0000f21a5, 0x4, 0xc0000f21aa, 0x0, 0xc0013cbaf0, 0x4fb9d1)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/pkg/where/match.go:159 +0x797
github.com/lomik/graphite-clickhouse/finder.TaggedTermWhereN(0xc0000ec1b8, 0xc0005661c0, 0x67, 0x0, 0x0)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/finder/tagged.go:168 +0xb9
github.com/lomik/graphite-clickhouse/finder.TaggedWhere(0xc0000ec0f0, 0x6, 0x6, 0xc0012f8300, 0x1, 0xc0000f21a5, 0x0)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/finder/tagged.go:280 +0x107
github.com/lomik/graphite-clickhouse/finder.(*TaggedFinder).ExecutePrepared(0xc000206410, 0x1c43b80, 0xc003aa69c0, 0xc0000ec0f0, 0x6, 0x6, 0x608358ab, 0x608382db, 0x57949c, 0x401120)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/finder/tagged.go:300 +0x5d
github.com/lomik/graphite-clickhouse/finder.(*TaggedFinder).Execute(0xc000206410, 0x1c43b80, 0xc003aa69c0, 0xc0000f2120, 0x8d, 0x608358ab, 0x608382db, 0x1c43fe0, 0xc000206410)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/finder/tagged.go:296 +0xc5
github.com/lomik/graphite-clickhouse/finder.Find(0xc00016a280, 0x1c43b80, 0xc003aa69c0, 0xc0000f2120, 0x8d, 0x608358ab, 0x608382db, 0xc001e1b260, 0xc00128e780, 0xc0005df770, ...)
/home/msv/go/src/github.com/lomik/graphite-clickhouse/finder/finder.go:82 +0xe2
github.com/lomik/graphite-clickhouse/render.(*Handler).ServeHTTP.func2(0xc000768280, 0xc00021af98, 0xc005444c00, 0xc001e1b800, 0xc0005fe1c8, 0xc000200870, 0xc000768290, 0x608358ab, 0x608382db, 0x7fffffffffffffff, ...)
```
