### PR TITLE
Hotfix "the same TimeFrame for all conditions"

### DIFF
--- a/render/data/multi_fetch_data.go
+++ b/render/data/multi_fetch_data.go
@@ -55,6 +55,7 @@ func (m *MultiFetchRequest) Fetch(ctx context.Context, cfg *config.Config, chCon
 	query := newQuery(cfg, len(*m))
 
 	for tf, targets := range *m {
+		tf, targets := tf, targets
 		cond := &conditions{TimeFrame: &tf, Targets: targets, aggregated: cfg.ClickHouse.InternalAggregation}
 		if cond.MaxDataPoints <= 0 || int64(cfg.ClickHouse.MaxDataPoints) < cond.MaxDataPoints {
 			cond.MaxDataPoints = int64(cfg.ClickHouse.MaxDataPoints)


### PR DESCRIPTION
w/o this patch all conditions for MultiFetchRequest have the pointer to the last TimeFrame