### PR TITLE
Fix finder useReverseDepth and add tests

### DIFF
--- a/finder/index.go
+++ b/finder/index.go
@@ -53,15 +53,6 @@ func (idx *IndexFinder) where(query string, levelOffset int) *where.Where {
 	return w
 }
 
-func useReverse(query string) bool {
-	p := strings.LastIndexByte(query, '.')
-
-	if !where.HasWildcard(query) || p < 0 || p >= len(query)-1 || where.HasWildcard(query[p+1:]) {
-		return false
-	}
-	return true
-}
-
 func reverseSuffixDepth(query string, defaultReverseDepth int, revUse []*config.NValue) int {
 	for i := range revUse {
 		if len(revUse[i].Prefix) > 0 && !strings.HasPrefix(query, revUse[i].Prefix) {
@@ -91,7 +82,11 @@ func useReverseDepth(query string, reverseDepth int, revUse []*config.NValue) bo
 		if reverseDepth == 0 {
 			return false
 		} else if reverseDepth == 1 {
-			return useReverse(query)
+			if len(query) <= w+1 {
+				return where.HasWildcard(query[:w])
+			}
+			p := strings.IndexByte(query[w+1:], '.') + w + 1
+			return where.HasWildcard(query[:p])
 		}
 	} else {
 		reverseDepth = 1

--- a/finder/index_test.go
+++ b/finder/index_test.go
@@ -17,10 +17,14 @@ func Test_useReverse(t *testing.T) {
 	}{
 		{"a.b.c.d.e", false},
 		{"a.b*", false},
+		{"a*.", true},
+		{"a*", false},
 		{"a.b.c.d.e*", false},
-		{"a.b.c.d*.e", true},
+		{"a.b*.c.d.e", true},
 		{"a.b*.c*.d.e", true},
 		{"a.b*.c*.d*.e", true},
+		{"a.b.c*.d*.e", false},
+		{"a.b.c.d*.e", false},
 	}
 
 	for _, tt := range table {
@@ -36,16 +40,26 @@ func Test_useReverseWithFixedDepth(t *testing.T) {
 		depth  int
 		result bool
 	}{
-		{"a.b.c.d.e", 0, false},
+		{"a*.b.c.d.e", -1, false},
+		{"a*.b.c.d.e", 0, true},
+		{"a.b*.c.d.e", 0, false},
+		{"a.b.c.d.e*", 0, false},
+		{"a.b*", 1, false},
+		{"a*.b", 1, true},
 		{"a.b.c.d.e", 1, false},
 		{"a.b.c.d.e*", 1, false},
-		{"a.b.c.d*.e", 1, true},
+		{"a.b.c.d*.e", 1, false},
+		{"a.b*.c.d.e", 1, true},
+		{"a.b.c.*.e.*.j", 1, false},
 		{"a.b.c.d*.e", 2, false},
 		{"a*.b.c.d*.e", 2, true}, // Wildcard at first level, use reverse if possible
 		{"a.b*.c.d*.e", 2, false},
+		{"a.b*.c.d", 2, true},
+		{"a.b.c*.d", 2, false},
+		{"a.b.c*.d.e", 2, true},
 		{"a.*.c.*.e.*.j", 2, false},
-		{"a.*.c.*.e.*.j", 1, true},
-		{"a.b*.c.*d.e", 2, false},
+		{"a.b.c.d.e*.f*.g*.h*", 2, false},
+		{"a.b.c.d.*e.f.g.h.i", 4, true},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
As discussed in https://t.me/ru_go_graphite/2889, it shouldn't revert metrics like "a.b.c.d*.e" when depth=1

cc: @msaf1980