### PR TITLE
Simplify logic of usage reversed index query

### DIFF
--- a/finder/finder.go
+++ b/finder/finder.go
@@ -43,8 +43,8 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 			config.ClickHouse.Url,
 			config.ClickHouse.IndexTable,
 			config.ClickHouse.IndexUseDaily,
-			config.ClickHouse.IndexReverseDepth,
-			config.ClickHouse.IndexUseReverses,
+			config.ClickHouse.IndexReverse,
+			config.ClickHouse.IndexReverses,
 			clickhouse.Options{
 				Timeout:        config.ClickHouse.IndexTimeout.Value(),
 				ConnectTimeout: config.ClickHouse.ConnectTimeout.Value(),

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -68,12 +68,12 @@ func HasWildcard(target string) bool {
 	return strings.IndexAny(target, "[]{}*?") > -1
 }
 
-func IndexReverseWildcard(target string) int {
+func IndexLastWildcard(target string) int {
 	return strings.LastIndexAny(target, "[]{}*?")
 }
 
-func IndexWildcardOrDot(target string) int {
-	return strings.IndexAny(target, ".[]{}*?")
+func IndexWildcard(target string) int {
+	return strings.IndexAny(target, "[]{}*?")
 }
 
 func NonRegexpPrefix(expr string) string {


### PR DESCRIPTION
- Reversed metrix quried from index when the first node with globe in
  the metric name closer to start than the latest to end.
- IndexReverses overwrite if query should be reversed.

It was a long discussion in telegram https://t.me/ru_go_graphite/2884, but we decided to give a try.

@msaf1980, test it in your environment, please
