### PR TITLE
Implement packagecloud upload for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
           sha256sum
           md5sum
 
+    - name: Push packages to the stable repo
+      run: make packagecloud-stable
+      env:
+        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
   upload:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,19 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1
+
     - uses: actions/checkout@v2
       name: Checkout
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
     - name: Install packaging dependencies
       run: |
-        sudo apt-get install rpm ruby-dev
-        sudo gem install fpm
+        gem install fpm package_cloud
         GO111MODULE=off go get github.com/mitchellh/gox
+
     - name: Build packages
       id: build
       run: |
@@ -35,11 +41,13 @@ jobs:
         # Upload all deb and rpm packages
         for package in *deb *rpm; do ARTIFACTS=${ARTIFACTS}\"$package\",\ ; done
         echo ::set-output name=matrix::{\"file\": [${ARTIFACTS} \"sha256sum\", \"md5sum\"]}
+
     - name: Check version
       id: check_version
       run: |
         ./out/${BINARY}-linux-amd64 -version
         [ v$(./out/${BINARY}-linux-amd64 -version) = ${{ github.event.release.tag_name }} ]
+
     - name: Artifact
       id: artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         go:
-          - ^1.13
           - ^1.14
           - ^1.15
+          - ^1.16
           - ^1
     steps:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,17 +49,19 @@ jobs:
     - name: Test
       run: make test
 
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
+
     - name: Install packaging dependencies
       run: |
-        sudo apt-get install rpm ruby-dev
-        sudo gem install fpm
+        gem install fpm package_cloud
+        GO111MODULE=off go get github.com/mitchellh/gox
 
     - name: Check packaging
       run: |
-        GO111MODULE=off go get github.com/mitchellh/gox
-        make gox-build
-        make DEVEL=1 fpm-deb
-        make DEVEL=1 fpm-rpm
+        make DEVEL=1 gox-build fpm-deb fpm-rpm
         make sum-files
 
     - name: Artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Checkout to the latest code
+    - name: Checkout to the latest tag
       run: |
         # Fetch all tags
         git fetch --depth=1 --tags

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         VERS=$(git tag -l | sort -Vr | head -n1)
         # Fetch everything to the latest tag
         git fetch --shallow-since=$(git log $VERS -1 --format=%at)
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' }} # only when built from master
 
     - name: Build project
       run: make
@@ -74,3 +74,9 @@ jobs:
           *.rpm
           sha256sum
           md5sum
+
+    - name: Push packages to the autobuilds repo
+      if: ${{ github.event_name == 'push' && matrix.go == '^1' }} # only when built from master with latest go
+      run: make packagecloud-autobuilds
+      env:
+        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: $(NAME)
 
 .PHONY: clean
 clean:
-	rm $(NAME)
+	rm -f $(NAME)
 	rm -rf out
 	rm -f *deb *rpm
 	rm -f sha256sum md5sum

--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,10 @@ packagecloud-push:
 	package_cloud push $(REPO)/el/7 $(NAME)-$(VERSION)-1.x86_64.rpm || true
 	package_cloud push $(REPO)/ubuntu/xenial $(NAME)_$(VERSION)_amd64.deb || true
 	package_cloud push $(REPO)/ubuntu/bionic $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/ubuntu/disco $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/ubuntu/eoan $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/debian/buster $(NAME)_$(VERSION)_amd64.deb || true
+	package_cloud push $(REPO)/ubuntu/focal $(NAME)_$(VERSION)_amd64.deb || true
 	package_cloud push $(REPO)/debian/stretch $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/debian/jessie $(NAME)_$(VERSION)_amd64.deb || true
+	package_cloud push $(REPO)/debian/buster $(NAME)_$(VERSION)_amd64.deb || true
+	package_cloud push $(REPO)/debian/bullseye $(NAME)_$(VERSION)_amd64.deb || true
 
 packagecloud-autobuilds:
 	$(MAKE) packagecloud-push REPO=go-graphite/autobuilds


### PR DESCRIPTION
This fixes #164 

- Update actual go versions
- Update releases for packages
- Push master to autobuilds
- Push releases to stable

It's better to merge this change before #166 