### PR TITLE
Fix packagecloud push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,6 @@ jobs:
 
     - name: Push packages to the autobuilds repo
       if: ${{ github.event_name == 'push' && matrix.go == '^1' }} # only when built from master with latest go
-      run: make packagecloud-autobuilds
+      run: make DEVEL=1 packagecloud-autobuilds
       env:
         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -90,15 +90,28 @@ fpm-build-rpm:
 		deploy/root/=/ \
 		out/root/=/
 
+.ONESHELL:
+RPM_VERSION:=$(subst -,_,$(VERSION))
+packagecloud-push-rpm: $(wildcard $(NAME)-$(RPM_VERSION)-1.*.rpm)
+	for pkg in $^; do
+		package_cloud push $(REPO)/el/7 $${pkg} || true
+		package_cloud push $(REPO)/el/8 $${pkg} || true
+	done
+
+.ONESHELL:
+packagecloud-push-deb: $(wildcard $(NAME)_$(VERSION)_*.deb)
+	for pkg in $^; do
+		package_cloud push $(REPO)/ubuntu/xenial   $${pkg} || true
+		package_cloud push $(REPO)/ubuntu/bionic   $${pkg} || true
+		package_cloud push $(REPO)/ubuntu/focal    $${pkg} || true
+		package_cloud push $(REPO)/debian/stretch  $${pkg} || true
+		package_cloud push $(REPO)/debian/buster   $${pkg} || true
+		package_cloud push $(REPO)/debian/bullseye $${pkg} || true
+	done
+
 packagecloud-push:
-	package_cloud push $(REPO)/el/8 $(NAME)-$(VERSION)-1.x86_64.rpm || true
-	package_cloud push $(REPO)/el/7 $(NAME)-$(VERSION)-1.x86_64.rpm || true
-	package_cloud push $(REPO)/ubuntu/xenial $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/ubuntu/bionic $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/ubuntu/focal $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/debian/stretch $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/debian/buster $(NAME)_$(VERSION)_amd64.deb || true
-	package_cloud push $(REPO)/debian/bullseye $(NAME)_$(VERSION)_amd64.deb || true
+	@$(MAKE) packagecloud-push-rpm
+	@$(MAKE) packagecloud-push-deb
 
 packagecloud-autobuilds:
 	$(MAKE) packagecloud-push REPO=go-graphite/autobuilds


### PR DESCRIPTION
It fixes #164 

- RPM: fix version for DEVEL
- TESTS ACTION: use a proper DEVEL version
- PUSH: push both amd64 and arm64 packages

Here's an example of run
```
> make DEVEL=1 packagecloud-autobuilds
make packagecloud-push REPO=go-graphite/autobuilds
make[1]: Entering directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
make[2]: Entering directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
for pkg in graphite-clickhouse-0.13.0_11_ga07bf0c-1.aarch64.rpm graphite-clickhouse-0.13.0_11_ga07bf0c-1.x86_64.rpm; do
package_cloud push go-graphite/autobuilds/el/7 ${pkg} || true
package_cloud push go-graphite/autobuilds/el/8 ${pkg} || true
done
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse-0.13.0_11_ga07bf0c-1.aarch64.rpm... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse-0.13.0_11_ga07bf0c-1.aarch64.rpm... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse-0.13.0_11_ga07bf0c-1.x86_64.rpm... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse-0.13.0_11_ga07bf0c-1.x86_64.rpm... error:

        filename: has already been taken

make[2]: Leaving directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
make[2]: Entering directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
for pkg in graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb; do
package_cloud push go-graphite/autobuilds/ubuntu/xenial   ${pkg} || true
package_cloud push go-graphite/autobuilds/ubuntu/bionic   ${pkg} || true
package_cloud push go-graphite/autobuilds/ubuntu/focal    ${pkg} || true
package_cloud push go-graphite/autobuilds/debian/stretch  ${pkg} || true
package_cloud push go-graphite/autobuilds/debian/buster   ${pkg} || true
package_cloud push go-graphite/autobuilds/debian/bullseye ${pkg} || true
done
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_amd64.deb... error:

        filename: has already been taken

Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
Using https://packagecloud.io with token:******64c4
Looking for repository at go-graphite/autobuilds... success!
Pushing graphite-clickhouse_0.13.0-11-ga07bf0c_arm64.deb... success!
make[2]: Leaving directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
make[1]: Leaving directory '/home/felixoid/OPT/Felixoid/github/lomik/graphite-clickhouse'
```