### PR TITLE
ClickHouse connection timeout is configured with the wrong parameter.

### DIFF
--- a/render/data/query.go
+++ b/render/data/query.go
@@ -99,7 +99,7 @@ func newQuery(cfg *config.Config, targets int) *query {
 		cStep:            cStep,
 		chURL:            cfg.ClickHouse.URL,
 		chDataTimeout:    cfg.ClickHouse.DataTimeout,
-		chConnectTimeout: cfg.Carbonlink.ConnectTimeout,
+		chConnectTimeout: cfg.ClickHouse.ConnectTimeout,
 		debugDir:         cfg.Debug.Directory,
 		debugExtDataPerm: cfg.Debug.ExternalDataPerm,
 		lock:             sync.RWMutex{},


### PR DESCRIPTION
ClickHouse connection timeout should be controlled by cfg.Clickhouse.ConnectTimeout option, not cfg.Carbonlink.ConnectTimeout