### PR TITLE
Promethues querier. Constrain maximum timestamp.

### DIFF
--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -1,3 +1,4 @@
+//go:build !noprom
 // +build !noprom
 
 package prometheus
@@ -43,7 +44,8 @@ func (q *Querier) Select(selectParams *storage.SelectParams, labelsMatcher ...*l
 	if from.IsZero() && q.mint > 0 {
 		from = time.Unix(q.mint/1000, (q.mint%1000)*1000000)
 	}
-	if until.IsZero() && q.maxt > 0 {
+	// ClickHouse supported Datetime range of values: [1970-01-01 00:00:00, 2105-12-31 23:59:59]
+	if until.IsZero() && q.maxt > 0 && q.maxt <= 4291765199000 {
 		until = time.Unix(q.maxt/1000, (q.maxt%1000)*1000000)
 	}
 


### PR DESCRIPTION
Fixes
````
# curl 'http://127.0.0.1:9010/api/v1/series?' --data-urlencode "match[]=up"
{"status":"error","errorType":"execution","error":"clickhouse response status 400: Code: 53, e.displayText() = DB::Exception: Cannot convert string 292277025-08-11 to type Date: while executing 'FUNCTION greaterOrEquals(Date : 0, '292277025-08-11' : 1) -\u003e greaterOrEquals(Date, '292277025-08-11') UInt8 : 3' (version 21.3.15.4.altinity+stable (altinity build))\n"
````