### PR TITLE
Log carbonapi uuid and request headers

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
+	"go.uber.org/zap"
 )
 
 type Handler struct {
@@ -40,6 +41,10 @@ func NewValues(config *config.Config) *Handler {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := scope.Logger(r.Context()).Named("autocomplete")
+	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
+	if carbonapiUUID != "" {
+		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 
 	// Don't process, if the tagged table is not set

--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -12,10 +12,8 @@ import (
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/finder"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
-	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
-	"go.uber.org/zap"
 )
 
 type Handler struct {
@@ -41,15 +39,7 @@ func NewValues(config *config.Config) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	logger := scope.Logger(r.Context()).Named("autocomplete")
-	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
-	if carbonapiUUID != "" {
-		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
-	}
-	requestHeaders := headers.GetHeaders(&r.Header, h.config.Common.HeadersToLog)
-	if len(requestHeaders) > 0 {
-		logger = logger.With(zap.Any("request_headers", requestHeaders))
-	}
+	logger := scope.LoggerWithHeaders(r.Context(), r, h.config.Common.HeadersToLog).Named("autocomplete")
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 
 	// Don't process, if the tagged table is not set

--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/finder"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
 	"go.uber.org/zap"
@@ -44,6 +45,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
 	if carbonapiUUID != "" {
 		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
+	requestHeaders := headers.GetHeaders(&r.Header, h.config.Common.HeadersToLog)
+	if len(requestHeaders) > 0 {
+		logger = logger.With(zap.Any("request_headers", requestHeaders))
 	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 

--- a/capabilities/handler.go
+++ b/capabilities/handler.go
@@ -8,6 +8,7 @@ import (
 
 	v3pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/pkg/scope"
 )
 
 type Handler struct {
@@ -21,6 +22,10 @@ func NewHandler(config *config.Config) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	logger := scope.LoggerWithHeaders(r.Context(), r, h.config.Common.HeadersToLog).Named("capabilities")
+
+	r = r.WithContext(scope.WithLogger(r.Context(), logger))
+
 	r.ParseMultipartForm(1024 * 1024)
 
 	format := r.FormValue("format")

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Common struct {
 	TargetBlacklist        []string         `toml:"target-blacklist" json:"target-blacklist" comment:"daemon returns empty response if query matches any of regular expressions" commented:"true"`
 	Blacklist              []*regexp.Regexp `toml:"-" json:"-"` // compiled TargetBlacklist
 	MemoryReturnInterval   time.Duration    `toml:"memory-return-interval" json:"memory-return-interval" comment:"daemon will return the freed memory to the OS when it>0"`
+	HeadersToLog           []string         `toml:"headers-to-log" json:"headers-to-log" comment:"additional request headers to log"`
 }
 
 // IndexReverseRule contains rules to use direct or reversed request to index table

--- a/doc/config.md
+++ b/doc/config.md
@@ -94,6 +94,8 @@ It's possible to set multiple loggers. See `Config` description in [config.go](h
  # target-blacklist = []
  # daemon will return the freed memory to the OS when it>0
  memory-return-interval = "0s"
+ # additional headers to log
+ headers-to-log = []
 
 [clickhouse]
  # see https://clickhouse.tech/docs/en/interfaces/http
@@ -228,4 +230,4 @@ It's possible to set multiple loggers. See `Config` description in [config.go](h
  sample-initial = 0
  # every m-th message logged thereafter per tick
  sample-thereafter = 0
-```
+ ```

--- a/doc/config.md
+++ b/doc/config.md
@@ -94,7 +94,7 @@ It's possible to set multiple loggers. See `Config` description in [config.go](h
  # target-blacklist = []
  # daemon will return the freed memory to the OS when it>0
  memory-return-interval = "0s"
- # additional headers to log
+ # additional request headers to log
  headers-to-log = []
 
 [clickhouse]
@@ -230,4 +230,4 @@ It's possible to set multiple loggers. See `Config` description in [config.go](h
  sample-initial = 0
  # every m-th message logged thereafter per tick
  sample-thereafter = 0
- ```
+```

--- a/find/handler.go
+++ b/find/handler.go
@@ -8,9 +8,7 @@ import (
 	v3pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
-	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
-	"go.uber.org/zap"
 )
 
 type Handler struct {
@@ -24,15 +22,7 @@ func NewHandler(config *config.Config) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	logger := scope.Logger(r.Context()).Named("metrics-find")
-	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
-	if carbonapiUUID != "" {
-		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
-	}
-	requestHeaders := headers.GetHeaders(&r.Header, h.config.Common.HeadersToLog)
-	if len(requestHeaders) > 0 {
-		logger = logger.With(zap.Any("request_headers", requestHeaders))
-	}
+	logger := scope.LoggerWithHeaders(r.Context(), r, h.config.Common.HeadersToLog).Named("metrics-find")
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 	r.ParseMultipartForm(1024 * 1024)
 

--- a/find/handler.go
+++ b/find/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
+	"go.uber.org/zap"
 )
 
 type Handler struct {
@@ -23,6 +24,10 @@ func NewHandler(config *config.Config) *Handler {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := scope.Logger(r.Context()).Named("metrics-find")
+	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
+	if carbonapiUUID != "" {
+		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 	r.ParseMultipartForm(1024 * 1024)
 

--- a/find/handler.go
+++ b/find/handler.go
@@ -8,6 +8,7 @@ import (
 	v3pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"go.uber.org/zap"
 )
@@ -27,6 +28,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
 	if carbonapiUUID != "" {
 		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
+	requestHeaders := headers.GetHeaders(&r.Header, h.config.Common.HeadersToLog)
+	if len(requestHeaders) > 0 {
+		logger = logger.With(zap.Any("request_headers", requestHeaders))
 	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 	r.ParseMultipartForm(1024 * 1024)

--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -21,7 +21,6 @@ import (
 	"github.com/lomik/graphite-clickhouse/capabilities"
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/find"
-	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/index"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/prometheus"
@@ -76,21 +75,11 @@ func (app *App) Handler(handler http.Handler) http.Handler {
 		handler.ServeHTTP(writer, r)
 		d := time.Since(start)
 
-		logger := scope.Logger(r.Context()).Named("http")
+		logger := scope.LoggerWithHeaders(r.Context(), r, app.config.Common.HeadersToLog).Named("http")
 
 		grafana := scope.Grafana(r.Context())
 		if grafana != "" {
 			logger = logger.With(zap.String("grafana", grafana))
-		}
-
-		// Log carbonapi request uuid for requests trace
-		carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
-		if carbonapiUUID != "" {
-			logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
-		}
-		requestHeaders := headers.GetHeaders(&r.Header, app.config.Common.HeadersToLog)
-		if len(requestHeaders) > 0 {
-			logger = logger.With(zap.Any("request_headers", requestHeaders))
 		}
 
 		var peer string

--- a/helper/headers/headers.go
+++ b/helper/headers/headers.go
@@ -1,0 +1,17 @@
+package headers
+
+import "net/http"
+
+func GetHeaders(header *http.Header, keys []string) map[string]string {
+	if len(keys) > 0 {
+		headers := make(map[string]string)
+		for _, key := range keys {
+			value := header.Get(key)
+			if len(value) > 0 {
+				headers[key] = value
+			}
+		}
+		return headers
+	}
+	return nil
+}

--- a/index/handler.go
+++ b/index/handler.go
@@ -18,7 +18,7 @@ func NewHandler(config *config.Config) *Handler {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	logger := scope.Logger(r.Context()).Named("index")
+	logger := scope.LoggerWithHeaders(r.Context(), r, h.config.Common.HeadersToLog).Named("index")
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 	i, err := New(h.config, r.Context())
 	if err != nil {

--- a/pkg/scope/logger.go
+++ b/pkg/scope/logger.go
@@ -2,9 +2,16 @@ package scope
 
 import (
 	"context"
+	"net/http"
 
+	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/zapwriter"
 	"go.uber.org/zap"
+)
+
+var (
+	CarbonapiUUIDName  = "carbonapi_uuid"
+	RequestHeadersName = "request_headers"
 )
 
 // Logger returns zap.Logger instance
@@ -24,6 +31,37 @@ func Logger(ctx context.Context) *zap.Logger {
 	requestId := RequestID(ctx)
 	if requestId != "" {
 		zapLogger = zapLogger.With(zap.String("request_id", requestId))
+	}
+
+	return zapLogger
+}
+
+// Logger returns zap.Logger instance
+func LoggerWithHeaders(ctx context.Context, r *http.Request, headersToLog []string) *zap.Logger {
+	logger := ctx.Value(scopeKey("logger"))
+	var zapLogger *zap.Logger
+	if logger != nil {
+		if zl, ok := logger.(*zap.Logger); ok {
+			zapLogger = zl
+			return zapLogger
+		}
+	}
+	if zapLogger == nil {
+		zapLogger = zapwriter.Default()
+	}
+
+	requestId := RequestID(ctx)
+	if requestId != "" {
+		zapLogger = zapLogger.With(zap.String("request_id", requestId))
+	}
+
+	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
+	if carbonapiUUID != "" {
+		zapLogger = zapLogger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
+	requestHeaders := headers.GetHeaders(&r.Header, headersToLog)
+	if len(requestHeaders) > 0 {
+		zapLogger = zapLogger.With(zap.Any("request_headers", requestHeaders))
 	}
 
 	return zapLogger

--- a/render/handler.go
+++ b/render/handler.go
@@ -33,6 +33,10 @@ func NewHandler(config *config.Config) *Handler {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := scope.Logger(r.Context()).Named("render")
+	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
+	if carbonapiUUID != "" {
+		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 
 	var err error

--- a/render/handler.go
+++ b/render/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/finder"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/headers"
 	"github.com/lomik/graphite-clickhouse/pkg/alias"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/render/data"
@@ -36,6 +37,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	carbonapiUUID := r.Header.Get("X-Ctx-Carbonapi-Uuid")
 	if carbonapiUUID != "" {
 		logger = logger.With(zap.String("carbonapi_uuid", carbonapiUUID))
+	}
+	requestHeaders := headers.GetHeaders(&r.Header, h.config.Common.HeadersToLog)
+	if len(requestHeaders) > 0 {
+		logger = logger.With(zap.Any("request_headers", requestHeaders))
 	}
 	r = r.WithContext(scope.WithLogger(r.Context(), logger))
 


### PR DESCRIPTION
Some simplify find query info:
1) Log carbonapi_uuid in complete query chain
2) Allow to log additional response headers (for example, may be in future grafana request id for completely trace queries)
