### PR TITLE
Optimize tagged finder when tagged-use-daily=false

### DIFF
--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -437,6 +437,12 @@ func (t *TaggedFinder) whereFilter(terms []TaggedTerm, from int64, until int64) 
 			date.FromTimestampToDaysFormat(from),
 			date.UntilTimestampToDaysFormat(until),
 		)
+	} else {
+
+		w.Andf(
+			"Date >='%s'",
+			date.FromTimestampToDaysFormat(from),
+		)
 	}
 	return w, pw, nil
 }

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -293,8 +293,9 @@ func TestTaggedFinder_whereFilter(t *testing.T) {
 			from:         1668106860, // 2022-11-11 00:01:00 +05:00
 			until:        1668106870, // 2022-11-11 00:01:10 +05:00
 			dailyEnabled: false,
-			want:         "Tag1='__name__=metric'",
-			wantPre:      "",
+			want: "(Tag1='__name__=metric') AND (Date >='" +
+				date.FromTimestampToDaysFormat(1668106860) + "')",
+			wantPre: "",
 		},
 		{
 			name:         "midnight at utc (direct)",


### PR DESCRIPTION
Even if *tagged-use-daily=false*, we still store Date and can use it to filter out series which won't participate in the further execution anyway.