### PR TITLE
adjust auto rollup for CH 25.8 (int64 no longer is a string in json)

### DIFF
--- a/helper/rollup/remote.go
+++ b/helper/rollup/remote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,8 +17,8 @@ type rollupRulesResponseRecord struct {
 	RuleType  RuleType `json:"rule_type"`
 	Regexp    string   `json:"regexp"`
 	Function  string   `json:"function"`
-	Age       string   `json:"age"`
-	Precision string   `json:"precision"`
+	Age       uint64   `json:"age"`
+	Precision uint64   `json:"precision"`
 	IsDefault int      `json:"is_default"`
 }
 type rollupRulesResponse struct {
@@ -39,17 +38,7 @@ func parseJson(body []byte) (*Rules, error) {
 	}
 
 	makeRetention := func(d *rollupRulesResponseRecord) (Retention, error) {
-		age, err := strconv.ParseInt(d.Age, 10, 32)
-		if err != nil {
-			return Retention{}, err
-		}
-
-		prec, err := strconv.ParseInt(d.Precision, 10, 32)
-		if err != nil {
-			return Retention{}, err
-		}
-
-		return Retention{Age: uint32(age), Precision: uint32(prec)}, nil
+		return Retention{Age: uint32(d.Age), Precision: uint32(d.Precision)}, nil
 	}
 
 	last := func() *Pattern {
@@ -69,8 +58,7 @@ func parseJson(body []byte) (*Rules, error) {
 			if d.Function != "" {
 				defaultFunction = d.Function
 			}
-
-			if d.Age != "" && d.Precision != "" && d.Precision != "0" {
+			if d.Precision != 0 {
 				rt, err := makeRetention(&d)
 				if err != nil {
 					return nil, err
@@ -87,8 +75,7 @@ func parseJson(body []byte) (*Rules, error) {
 					Function:  d.Function,
 				})
 			}
-
-			if d.Age != "" && d.Precision != "" && d.Precision != "0" {
+			if d.Precision != 0 {
 				rt, err := makeRetention(&d)
 				if err != nil {
 					return nil, err

--- a/helper/rollup/remote.go
+++ b/helper/rollup/remote.go
@@ -58,6 +58,7 @@ func parseJson(body []byte) (*Rules, error) {
 			if d.Function != "" {
 				defaultFunction = d.Function
 			}
+
 			if d.Precision != 0 {
 				rt, err := makeRetention(&d)
 				if err != nil {
@@ -75,6 +76,7 @@ func parseJson(body []byte) (*Rules, error) {
 					Function:  d.Function,
 				})
 			}
+
 			if d.Precision != 0 {
 				rt, err := makeRetention(&d)
 				if err != nil {

--- a/helper/rollup/remote_test.go
+++ b/helper/rollup/remote_test.go
@@ -49,50 +49,50 @@ func TestParseJson(t *testing.T) {
 		{
 			"regexp": "^hourly",
 			"function": "",
-			"age": "0",
-			"precision": "3600",
+			"age": 0,
+			"precision": 3600,
 			"is_default": 0
 		},
 		{
 			"regexp": "^hourly",
 			"function": "",
-			"age": "3600",
-			"precision": "13600",
+			"age": 3600,
+			"precision": 13600,
 			"is_default": 0
 		},
 		{
 			"regexp": "^live",
 			"function": "",
-			"age": "0",
-			"precision": "1",
+			"age": 0,
+			"precision": 1,
 			"is_default": 0
 		},
 		{
 			"regexp": "total$",
 			"function": "sum",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
 			"regexp": "min$",
 			"function": "min",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
 			"regexp": "max$",
 			"function": "max",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
 			"regexp": "",
 			"function": "max",
-			"age": "0",
-			"precision": "60",
+			"age": 0,
+			"precision": 60,
 			"is_default": 1
 		}
 	],
@@ -162,48 +162,48 @@ func TestParseJsonTyped(t *testing.T) {
 			"rule_type": "all",
 			"regexp": "^hourly",
 			"function": "",
-			"age": "0",
-			"precision": "3600",
+			"age": 0,
+			"precision": 3600,
 			"is_default": 0
 		},
 		{
 			"rule_type": "all",
 			"regexp": "^hourly",
 			"function": "",
-			"age": "3600",
-			"precision": "13600",
+			"age": 3600,
+			"precision": 13600,
 			"is_default": 0
 		},
 		{
 			"rule_type": "all",
 			"regexp": "^live",
 			"function": "",
-			"age": "0",
-			"precision": "1",
+			"age": 0,
+			"precision": 1,
 			"is_default": 0
 		},
 		{
 			"rule_type": "plain",
 			"regexp": "total$",
 			"function": "sum",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
 			"rule_type": "plain",
 			"regexp": "min$",
 			"function": "min",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
 			"rule_type": "plain",
 			"regexp": "max$",
 			"function": "max",
-			"age": "0",
-			"precision": "0",
+			"age": 0,
+			"precision": 0,
 			"is_default": 0
 		},
 		{
@@ -220,8 +220,8 @@ func TestParseJsonTyped(t *testing.T) {
 			"rule_type": "all",
 			"regexp": "",
 			"function": "max",
-			"age": "0",
-			"precision": "60",
+			"age": 0,
+			"precision": 60,
 			"is_default": 1
 		}
 	],


### PR DESCRIPTION
fixes #321 

not tested atm. 

This PR modifies the struct rollupRulesResponseRecord to use int64 for age and precision.

At the moment this is a string. With ClickHouse 25.8 this is now an integer in the JSON. 